### PR TITLE
fix: Support scout navigate to specific scanner

### DIFF
--- a/src/providers/scanview/scanview-editor.ts
+++ b/src/providers/scanview/scanview-editor.ts
@@ -106,13 +106,12 @@ class ScoutScanReadonlyEditor implements vscode.CustomReadonlyEditorProvider {
     const logViewState: ScanviewState = {
       scan_dir: docUriNoParams,
       results_dir: dirname(docUriNoParams),
-      scan:
-        scanner && transcript_id
-          ? {
-              scanner: scanner,
-              transcript_id: transcript_id,
-            }
-          : undefined,
+      scan: scanner
+        ? {
+            scanner: scanner,
+            transcript_id: transcript_id,
+          }
+        : undefined,
     };
     webviewPanel.webview.html = this.scanviewPanel_.getHtml(logViewState);
     return Promise.resolve();

--- a/src/providers/scanview/scanview-state.ts
+++ b/src/providers/scanview/scanview-state.ts
@@ -5,7 +5,7 @@ export interface ScanviewState {
   results_dir: Uri;
   scan?: {
     scanner: string;
-    transcript_id: string;
+    transcript_id?: string;
   };
   background_refresh?: boolean;
 }


### PR DESCRIPTION
@jjallaire Doesn't seem like there is a way to specify a transcript_id - want you to confirm this looks right...