### PR TITLE
Add new scanner_df support to vscode

### DIFF
--- a/src/core/jsonrpc.ts
+++ b/src/core/jsonrpc.ts
@@ -16,6 +16,7 @@ export const kMethodEvalSet = "eval_set";
 // constants for Scout json-rpc methods
 export const kMethodGetScans = "get_scans";
 export const kMethodGetScan = "get_scan";
+export const kMethodGetScannerDataframe = "get_scanner_dataframe";
 
 // json rpc client (talk from the webview to the extension)
 export function webViewJsonRpcClient(vscode: {

--- a/src/providers/scanview/scanview-panel.ts
+++ b/src/providers/scanview/scanview-panel.ts
@@ -3,6 +3,7 @@ import { ExtensionContext, Uri } from "vscode";
 import { HostWebviewPanel } from "../../hooks";
 import {
   kMethodGetScan,
+  kMethodGetScannerDataframe,
   kMethodGetScans,
   webviewPanelJsonRpcServer,
 } from "../../core/jsonrpc";
@@ -30,6 +31,8 @@ export class ScanviewPanel extends Disposable {
       [kMethodGetScans]: async () => server.getScans(),
       [kMethodGetScan]: async (params: unknown[]) =>
         server.getScan(params[0] as string),
+      [kMethodGetScannerDataframe]: async (params: unknown[]) =>
+        server.getScannerDataframe(params[0] as string, params[1] as string),
     });
 
     // serve post message api to webview

--- a/src/providers/scout/scout-view-server.ts
+++ b/src/providers/scout/scout-view-server.ts
@@ -28,7 +28,19 @@ export class ScoutViewServer extends PackageViewServer {
   }
 
   async getScan(scanLocation: string): Promise<string> {
-    return this.api_json(`/api/scan/${encodeURIComponent(scanLocation)}`);
+    return this.api_json(
+      `/api/scan/${encodeURIComponent(scanLocation)}?status_only=true`
+    );
+  }
+
+  async getScannerDataframe(
+    scanLocation: string,
+    scanner: string
+  ): Promise<Uint8Array> {
+    const uri = `/api/scanner_df/${encodeURIComponent(
+      scanLocation
+    )}?scanner=${encodeURIComponent(scanner)}`;
+    return this.api_bytes(uri);
   }
 
   async deleteScan(scanLocation: Uri): Promise<string> {


### PR DESCRIPTION
This adds support for a new entry point to fetch scanner dataframes from the server. The existing entry points work identically so this will support both the new and old versions of scout.