### PR TITLE
fix: add --no-dependencies to vsce publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         run: pnpm vsce:package
 
       - name: Publish to VS Code Marketplace
-        run: pnpm vsce publish --pat ${{ secrets.VSCE_PAT }}
+        run: pnpm vsce publish --no-dependencies --pat ${{ secrets.VSCE_PAT }}
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 


### PR DESCRIPTION
## Summary
- Add `--no-dependencies` flag to `vsce publish` in the release workflow
- Fixes publish failure caused by `vsce` shelling out to `npm list --production`, which doesn't understand pnpm's `node_modules` layout
- `@microsoft/fast-components` has many peer/dev deps (karma, storybook, rollup, etc.) that `npm list` expects but aren't installed

The `vsce:package` script already uses `--no-dependencies` — this aligns `publish` to match.

## Test plan
- [x] Verified the workflow change is a single-line flag addition
- [x] Next release-please triggered publish should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)