### PR TITLE
feat: Add a notification when the extension can't find inspect-ai in the python environment

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,10 @@
 import { ExtensionContext, MessageItem, window } from "vscode";
 
 import { Command, CommandManager } from "./core/command";
-import { end, start } from "./core/log";
+import { end, log, start } from "./core/log";
 import { PackageManager } from "./core/package/manager";
 import { OutputWatcher } from "./core/package/output-watcher";
-import { initPythonInterpreter } from "./core/python";
+import { initPythonInterpreter, pythonInterpreter } from "./core/python";
 import { checkActiveWorkspaceFolder } from "./core/workspace";
 import { initInspectProps } from "./inspect";
 import { inspectBinPath, inspectVersionDescriptor } from "./inspect/props";
@@ -309,5 +309,11 @@ const checkInspectVersion = async () => {
         close
       );
     }
+  } else {
+    log.error("inspect-ai is not installed in the current Python environment.");
+    const envPath = pythonInterpreter().pythonBinDir ?? "unknown";
+    void window.showErrorMessage(
+      `inspect-ai is not installed in the current environment (${envPath}). Please install inspect-ai or switch to a different environment to view .eval files.`
+    );
   }
 };


### PR DESCRIPTION
This tripped me up a couple of times when VSCode uses an unexpected python environment, so proposing an explicit notification when the extension tries to view a .eval file but it isn't available.

**Testing**

- Manually attempt to view a .eval file when inspect-ai is not installed. (observed the two new messages)
- Manually view a .eval file when inspect-ai is installed in the environment (no visible changes from before this PR)
- Open VSCode where inspect-ai is missing from the python environment but do not try to view a .eval file (no notification observed), subsequently copy in a .eval file and try to view it (notification observed then)
- `pnpm check` passes
- I didn't add a unit test for this since the change is small and checkInspectVersion isn't currently exposed