### PR TITLE
fix: detect octet-stream responses as binary in serverFetch

### DIFF
--- a/src/core/package/view-server.ts
+++ b/src/core/package/view-server.ts
@@ -90,15 +90,20 @@ export class PackageViewServer implements Disposable {
     );
     const { status, headers: responseHeaders } = response;
 
-    const isBinary = responseHeaders
-      .get("Content-Type")
-      ?.includes("application/vnd.apache.arrow");
+    // Treat anything that isn't JSON or text/* as binary. Decoding raw bytes
+    // via response.text() corrupts non-UTF-8 sequences (e.g. zstd-compressed
+    // payloads served as application/octet-stream).
+    const contentType = responseHeaders.get("Content-Type") ?? "";
+    const isText =
+      contentType === "" ||
+      contentType.includes("application/json") ||
+      contentType.startsWith("text/");
 
     return {
       status,
-      data: isBinary
-        ? new Uint8Array(await response.arrayBuffer())
-        : await response.text(),
+      data: isText
+        ? await response.text()
+        : new Uint8Array(await response.arrayBuffer()),
       headers: responseHeaders,
     };
   }


### PR DESCRIPTION
`.eval` files recorded after https://github.com/UKGovernmentBEIS/inspect_ai/pull/3634 fail to load in vscode.


https://github.com/user-attachments/assets/10cbde89-d8b2-4ef6-8ffc-3686e86578a7



The previous binary check only matched `application/vnd.apache.arrow`, so zstd-compressed messages-events from `.eval` files (served as `application/octet-stream` with `X-Content-Encoding: zstd`) were decoded via `response.text()`, corrupting non-UTF-8 byte sequences. The webview then failed to decompress with "invalid zstd data".

Generalize the check to treat anything that isn't JSON or text/* as binary, with empty Content-Type defaulting to text for backward compatibility.