### PR TITLE
fix: Fix error opening S3 scans

### DIFF
--- a/src/providers/scanview/scanview-editor.ts
+++ b/src/providers/scanview/scanview-editor.ts
@@ -57,14 +57,14 @@ class ScoutScanReadonlyEditor implements vscode.CustomReadonlyEditorProvider {
     _token: vscode.CancellationToken
   ): Promise<void> {
     let scanDir = dirname(document.uri);
-    let scanJob = basename(document.uri);
+    let scanJob = decodeURIComponent(basename(document.uri));
     let scannerName = undefined;
 
     // If the uri ends with a parquet file, clip it off and use the
     // name of the parquet file as scanner
     if (scanJob.endsWith(".parquet")) {
       scannerName = scanJob.replace(/\.parquet$/, "");
-      scanJob = basename(scanDir);
+      scanJob = decodeURIComponent(basename(scanDir));
       scanDir = dirname(scanDir);
     }
 


### PR DESCRIPTION
Decode URI-encoded path segments in scanview editor for S3 URIs