### PR TITLE
fix: Scout View no longer resets app state when tabbed away (#91)

### DIFF
--- a/src/providers/scanview/scanview-view.ts
+++ b/src/providers/scanview/scanview-view.ts
@@ -100,11 +100,16 @@ export class ScoutViewWebviewManager extends InspectWebviewManager<
     return this.activeView_?.webviewPanel().viewColumn;
   }
 
-  protected override async onViewStateChanged(): Promise<void> {
-    if (this.isActive()) {
-      await this.updateVisibleView();
-    }
-  }
+  // NOTE: Unlike Inspect View, Scout View intentionally does NOT re-post its
+  // route to the webview on view-state changes (e.g. tabbing away and back).
+  //
+  // The Scout View webview is a self-contained SPA that owns its own routing
+  // and in-app state once loaded. Re-posting the last route on every focus
+  // change forced the app to navigate back to that top-level route, discarding
+  // wherever the user had navigated (open transcript, applied filter, etc.).
+  // Routes are only delivered on initial show (via setOnShow) and on explicit
+  // command-driven navigation (showScoutRoute with "activate"), so the base
+  // class no-op onViewStateChanged() is correct here.
 
   public showViewAndGotoRoute(
     route: RouteMessage,


### PR DESCRIPTION
Fixes #91

## Problem

The entire Scout View app reset to its default state whenever the user tabbed away from it and back. Inspect View did **not** have this problem in the same environment.

## Root cause

Both views share the same `InspectWebviewManager` base class, which already creates the panel with `retainContextWhenHidden: true`, so context retention was **not** the cause (contrary to the initial guess in the issue).

The actual culprit was Scout View's `onViewStateChanged` override in [scanview-view.ts](src/providers/scanview/scanview-view.ts):

```ts
protected override async onViewStateChanged(): Promise<void> {
  if (this.isActive()) {
    await this.updateVisibleView();   // re-posts the last route message
  }
}
```

`onDidChangeViewState` fires every time the panel gains/loses focus (including tab-away/tab-back). On each activation this re-posted the last `updateRoute` message to the webview. The Scout View webview is a self-contained SPA that owns its own routing, so receiving an `updateRoute` message forced it to navigate back to the stored top-level route (e.g. `/scans`), discarding wherever the user had navigated (open transcript, applied filter, etc.).

Inspect View's equivalent override is benign because its `update()` only re-asserts the current log *file* URL, which the Inspect app treats idempotently — the host never tracks the user's in-log position.

## Fix

Remove the focus-triggered re-post. Routes are still delivered:
- on initial show, via the `setOnShow` callback, and
- on explicit command-driven navigation, via `showScoutRoute(route, "activate")` which calls `activeView_.update()` directly.

So legitimate navigation is unaffected; only the spurious focus-change reset is removed.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` pass
- `pnpm test` — all 428 tests pass
- Manual verification recommended: open Scout View, navigate to a transcript/apply a filter, tab away to another editor, tab back — state should now be preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)