### PR TITLE
chore: repo config polish (URLs, capabilities, dependabot, security, README)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Inspect AI for VS Code
 
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/ukaisi.inspect-ai?label=VS%20Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=ukaisi.inspect-ai)
+[![Installs](https://img.shields.io/visual-studio-marketplace/i/ukaisi.inspect-ai)](https://marketplace.visualstudio.com/items?itemName=ukaisi.inspect-ai)
+[![CI](https://github.com/meridianlabs-ai/inspect_vscode/actions/workflows/ci.yml/badge.svg)](https://github.com/meridianlabs-ai/inspect_vscode/actions/workflows/ci.yml)
+
 VS Code extension for the [Inspect](https://inspect.aisi.org.uk/) framework for large language model evaluations. This extension provides support for developing evaluations using Inspect, including:
 
 - Integrated viewer for evaluation log files
@@ -8,10 +12,14 @@ VS Code extension for the [Inspect](https://inspect.aisi.org.uk/) framework for 
 - Panel for configuring task CLI options and args
 - Commands and key-bindings for running and debugging tasks
 
-## Prerequisites
+## Installation
+
+Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ukaisi.inspect-ai) or [OpenVSX](https://open-vsx.org/extension/ukaisi/inspect-ai), or search for "Inspect AI" in the Extensions view (`Ctrl+Shift+X`). A `.vsix` package is also attached to each [GitHub release](https://github.com/meridianlabs-ai/inspect_vscode/releases).
+
+### Prerequisites
 
 - [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) >= 0.3.8 installed in your active Python environment
-- Scout features (see below) only activate if [Inspect Scout](https://github.com/UKGovernmentBEIS/inspect_scout) is also installed
+- Scout features (see below) only activate if [Inspect Scout](https://github.com/meridianlabs-ai/inspect_scout) is also installed
 
 ## Log Viewer
 
@@ -39,7 +47,7 @@ Use the run or debug commands to execute the current task. You can alternatively
 
 ## Scout
 
-When [Inspect Scout](https://github.com/UKGovernmentBEIS/inspect_scout) is installed, the extension provides a dedicated Scout activity bar with additional features:
+When [Inspect Scout](https://github.com/meridianlabs-ai/inspect_scout) is installed, the extension provides a dedicated Scout activity bar with additional features:
 
 - **Scan Viewer** — Custom editor for browsing and inspecting scan results
 - **Scan Listing** — Tree view of all available scans with refresh, delete, and reveal-in-explorer actions
@@ -48,6 +56,21 @@ When [Inspect Scout](https://github.com/UKGovernmentBEIS/inspect_scout) is insta
 - **Project Configuration** — Detects and validates `scout.yml`/`scout.yaml` files in your workspace
 - **Scan Notifications** — Configurable notifications when scans complete, with a quick link to view results
 
+## Settings
+
+| Setting                                  | Default | Description                                                          |
+| ---------------------------------------- | ------- | -------------------------------------------------------------------- |
+| `inspect_ai.notifyEvalComplete`          | `true`  | Show a notification when an evaluation completes.                    |
+| `inspect_ai.notifyScanComplete`          | `true`  | Show a notification when a scan completes.                           |
+| `inspect_ai.taskListView`                | `tree`  | Display task outline as a tree or list.                              |
+| `inspect_ai.debugSingleSample`           | `true`  | Limit evaluation to one sample when debugging.                       |
+| `inspect_ai.debugSingleTranscript`       | `true`  | Limit scanning to one transcript when debugging.                     |
+| `inspect_ai.useSubdirectoryEnvironments` | `true`  | Run and debug commands using subdirectory environments when present. |
+
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines. To report a suspected security issue, please see [SECURITY.md](SECURITY.md).
+
+## License
+
+[MIT](LICENSE) © Meridian Labs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately using GitHub's
+[private vulnerability reporting](https://github.com/meridianlabs-ai/inspect_vscode/security/advisories/new)
+for this repository ("Security" tab → "Report a vulnerability").
+
+Please do **not** report security vulnerabilities through public GitHub issues.
+
+When reporting, please include:
+
+- A description of the issue and its potential impact
+- Steps to reproduce (a proof of concept is helpful but not required)
+- Affected extension version and VS Code/OS versions
+
+We will acknowledge reports within 5 business days and keep you informed as we
+work on a fix. We ask that you give us a reasonable opportunity to address the
+issue before any public disclosure.
+
+## Supported Versions
+
+Security fixes are released for the latest published version of the extension
+on the VS Code Marketplace and OpenVSX.
+
+## Scope
+
+This policy covers the Inspect AI VS Code extension. For issues in the
+underlying frameworks, see the
+[Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) and
+[Inspect Scout](https://github.com/meridianlabs-ai/inspect_scout)
+repositories.

--- a/package.json
+++ b/package.json
@@ -13,14 +13,24 @@
   "homepage": "https://inspect.aisi.org.uk/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/meridianlabs-ai/inspect-vscode/"
+    "url": "https://github.com/meridianlabs-ai/inspect_vscode/"
   },
   "bugs": {
-    "url": "https://github.com/meridianlabs-ai/inspect-vscode/issues"
+    "url": "https://github.com/meridianlabs-ai/inspect_vscode/issues"
   },
   "engines": {
     "vscode": "^1.85.0",
     "node": ">=22.0.0"
+  },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false,
+      "description": "Running and debugging tasks executes commands constructed from workspace contents, so the extension is disabled in untrusted workspaces."
+    },
+    "virtualWorkspaces": {
+      "supported": false,
+      "description": "The extension requires a local Python environment and file system access."
+    }
   },
   "categories": [
     "Machine Learning",


### PR DESCRIPTION
- Fix repository/bugs URLs in package.json (`inspect-vscode` → `inspect_vscode`)
- Declare `untrustedWorkspaces` / `virtualWorkspaces` capabilities
- Add `.github/dependabot.yml` (npm + github-actions, weekly)
- Add `SECURITY.md` with private vulnerability reporting policy
- README: badges, Installation section, settings reference table, license; fix dead `inspect_scout` links (`UKGovernmentBEIS` → `meridianlabs-ai`)

Note: enable "Private vulnerability reporting" in repo Settings → Security for the SECURITY.md link to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)