### PR TITLE
fix: harden webview CSP, URI handler, and nonce generation

### DIFF
--- a/src/components/webview.ts
+++ b/src/components/webview.ts
@@ -333,7 +333,7 @@ export abstract class InspectWebview<T> extends Disposable {
                         allowUnsafe ? "'unsafe-eval'" : ""
                       };
             connect-src ${this._webviewPanel.webview.cspSource} ;
-                      frame-src *;
+                      frame-src ${this._webviewPanel.webview.cspSource};
                       ">
   
                   ${headerHtml}

--- a/src/core/nonce.ts
+++ b/src/core/nonce.ts
@@ -1,9 +1,30 @@
+import { randomBytes } from "crypto";
+
+const kNonceChars =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+const kNonceLength = 64;
+
+// Generates a cryptographically strong nonce for use in webview
+// Content-Security-Policy headers. Math.random() is not a CSPRNG and its
+// output is predictable, which would undermine the nonce's purpose of
+// authorizing only the scripts we emit. We draw from crypto.randomBytes and
+// map onto an alphanumeric alphabet using rejection sampling to avoid the
+// modulo bias that would skew the character distribution.
 export function getNonce() {
+  // Largest multiple of the alphabet size that fits in a byte; bytes at or
+  // above this threshold are rejected so every character is equally likely.
+  const limit = Math.floor(256 / kNonceChars.length) * kNonceChars.length;
+
   let text = "";
-  const possible =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  for (let i = 0; i < 64; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  while (text.length < kNonceLength) {
+    for (const byte of randomBytes(kNonceLength)) {
+      if (byte < limit) {
+        text += kNonceChars.charAt(byte % kNonceChars.length);
+        if (text.length === kNonceLength) {
+          break;
+        }
+      }
+    }
   }
   return text;
 }

--- a/src/providers/protocol-handler.ts
+++ b/src/providers/protocol-handler.ts
@@ -4,9 +4,37 @@ import { commands, ExtensionContext, Uri, UriHandler, window } from "vscode";
 
 import { showError } from "../components/error";
 
+// Schemes we are willing to open a log from. Anyone can invoke this URI
+// handler, so we restrict it to local files and the remote backends Inspect
+// itself supports rather than forwarding arbitrary URIs to the view server.
+const kAllowedLogSchemes = ["file", "https", "http", "s3"];
+
+// Recognized Inspect log file extensions.
+const kAllowedLogExtensions = [".eval", ".json"];
+
 export function activateProtocolHandler(context: ExtensionContext) {
   const protocolHandler = new InspectProtocolHandler();
   context.subscriptions.push(window.registerUriHandler(protocolHandler));
+}
+
+/**
+ * Validates a log URI received from the (externally-invokable) URI handler.
+ *
+ * Anyone can navigate a browser to `vscode://ukaisi.inspect-ai/open?log=<uri>`,
+ * so we only forward URIs that look like an Inspect log on a backend we
+ * support, rather than passing arbitrary URIs to the view server. Returns an
+ * error message describing why the URI was rejected, or `null` if it is
+ * acceptable. Pure (no file-system access) so it can be unit tested.
+ */
+export function validateLogUri(uri: Uri): string | null {
+  if (!kAllowedLogSchemes.includes(uri.scheme)) {
+    return `Unable to open log: unsupported location "${uri.scheme}:".`;
+  }
+  const lowerPath = uri.path.toLowerCase();
+  if (!kAllowedLogExtensions.some((ext) => lowerPath.endsWith(ext))) {
+    return `Unable to open log: "${uri.path}" is not an Inspect log file.`;
+  }
+  return null;
 }
 
 export class InspectProtocolHandler implements UriHandler {
@@ -22,10 +50,19 @@ export class InspectProtocolHandler implements UriHandler {
         if (logFile) {
           const logUri = Uri.parse(logFile);
 
+          // This handler can be invoked by any web page (anyone can navigate to
+          // vscode://ukaisi.inspect-ai/open?log=<uri>), so validate the target
+          // before forwarding it to the log viewer.
+          const validationError = validateLogUri(logUri);
+          if (validationError) {
+            await showError(validationError);
+            return;
+          }
+
           // For local file paths, make sure the file exists or show an error
           if (logUri.scheme === "file") {
             if (!existsSync(logUri.fsPath)) {
-              await showError(`The file ${logUri.fsPath} does exist.`);
+              await showError(`The file ${logUri.fsPath} does not exist.`);
               return;
             }
           }

--- a/src/test/suite/protocol-handler.test.ts
+++ b/src/test/suite/protocol-handler.test.ts
@@ -1,0 +1,63 @@
+import * as assert from "assert";
+
+import { Uri } from "vscode";
+
+import { validateLogUri } from "../../providers/protocol-handler";
+
+suite("Protocol Handler Test Suite", () => {
+  suite("validateLogUri", () => {
+    test("accepts a local .eval file", () => {
+      assert.strictEqual(
+        validateLogUri(Uri.parse("file:///logs/run.eval")),
+        null
+      );
+    });
+
+    test("accepts a local .json log", () => {
+      assert.strictEqual(
+        validateLogUri(Uri.parse("file:///logs/run.json")),
+        null
+      );
+    });
+
+    test("accepts remote s3 and https logs", () => {
+      assert.strictEqual(
+        validateLogUri(Uri.parse("s3://bucket/run.eval")),
+        null
+      );
+      assert.strictEqual(
+        validateLogUri(Uri.parse("https://example.com/run.json")),
+        null
+      );
+    });
+
+    test("ignores case in the extension", () => {
+      assert.strictEqual(
+        validateLogUri(Uri.parse("file:///logs/RUN.EVAL")),
+        null
+      );
+    });
+
+    test("rejects unsupported schemes", () => {
+      const err = validateLogUri(Uri.parse("ssh://host/run.eval"));
+      assert.ok(err && err.includes("unsupported location"));
+    });
+
+    test("rejects a command scheme (would-be code execution vector)", () => {
+      const err = validateLogUri(
+        Uri.parse("command:workbench.action.terminal.new")
+      );
+      assert.ok(err, "command: URIs must be rejected");
+    });
+
+    test("rejects files that are not recognized logs", () => {
+      const err = validateLogUri(Uri.parse("file:///etc/passwd"));
+      assert.ok(err && err.includes("not an Inspect log file"));
+    });
+
+    test("rejects a log-looking query that is not actually a log file", () => {
+      const err = validateLogUri(Uri.parse("https://evil.example/page.html"));
+      assert.ok(err && err.includes("not an Inspect log file"));
+    });
+  });
+});


### PR DESCRIPTION
Four small, independent security hardening fixes.

### 1. URI handler validates its input — [protocol-handler.ts](src/providers/protocol-handler.ts)
The handler is externally invokable: any web page can navigate to `vscode://ukaisi.inspect-ai/open?log=<uri>` and the handler previously forwarded **any** URI (only `file:` got an existence check) into `inspect.openLogViewer`, which spins up the view server. Now we validate up front via a pure, unit-tested `validateLogUri()`:
- scheme must be one of `file` / `https` / `http` / `s3`
- path must end in a recognized log extension (`.eval` / `.json`)

Rejected URIs (e.g. `command:`, `ssh:`, `…/page.html`) get a clear error instead of being opened. Also fixes the typo `"The file … does exist."` → `"does not exist."`.

### 2. Tighten webview `frame-src` — [components/webview.ts](src/components/webview.ts)
`frame-src *` allowed framing arbitrary external origins. Restricted to the webview's own `cspSource`. (The SPA log viewer built in [core/webview.ts](src/core/webview.ts) has no `frame-src` at all, so it already inherits `default-src 'none'` — unchanged.)

### 3. Cryptographic nonce — [nonce.ts](src/core/nonce.ts)
`getNonce()` used `Math.random()`, which is not a CSPRNG and is predictable — undermining the CSP nonce. Switched to `crypto.randomBytes`, using rejection sampling to keep the existing 64-char alphanumeric contract (so the existing nonce tests still hold) without introducing modulo bias.

## Verification
`pnpm check` clean (lint + format + typecheck + tests). New `protocol-handler` tests cover hostile schemes (`command:`, `ssh:`) and non-log targets; existing `nonce` tests (length, alphabet, uniqueness, distribution) still pass against the CSPRNG implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)