### PR TITLE
fix: parse log task name with basename instead of split("/")

### DIFF
--- a/src/providers/lognotify.ts
+++ b/src/providers/lognotify.ts
@@ -1,9 +1,24 @@
-import { commands, ExtensionContext, MessageItem, window } from "vscode";
+import { commands, ExtensionContext, MessageItem, Uri, window } from "vscode";
 
 import { OutputWatcher } from "../core/package/output-watcher";
+import { basename } from "../core/uri";
 
 import { InspectViewManager } from "./logview/logview-view";
 import { InspectSettingsManager } from "./settings/inspect-settings";
+
+/**
+ * Derives a human-readable task name from a log URI.
+ *
+ * Inspect log files are named `<timestamp>_<task>_<id>.eval`, so the task is
+ * the second underscore-delimited segment of the filename. Uses basename()
+ * (which is separator- and scheme-aware) rather than splitting on "/", which
+ * was fragile for Windows-style paths.
+ */
+export function taskNameFromLog(log: Uri): string {
+  const fileName = basename(log);
+  const parts = fileName.split("_");
+  return parts[1] ?? "task";
+}
 
 export function activateLogNotify(
   context: ExtensionContext,
@@ -26,9 +41,7 @@ export function activateLogNotify(
       }
 
       // see if we can pick out the task name
-      const logFile = e.log.path.split("/").pop()!;
-      const parts = logFile?.split("_");
-      const task = parts.length > 1 ? parts[1] : "task";
+      const task = taskNameFromLog(e.log);
 
       // show the message
       const viewLog: MessageItem = { title: "View Log" };

--- a/src/test/suite/lognotify.test.ts
+++ b/src/test/suite/lognotify.test.ts
@@ -1,0 +1,44 @@
+import * as assert from "assert";
+
+import { Uri } from "vscode";
+
+import { taskNameFromLog } from "../../providers/lognotify";
+
+suite("LogNotify Test Suite", () => {
+  suite("taskNameFromLog", () => {
+    test("extracts the task name from a standard log filename", () => {
+      const uri = Uri.file(
+        "/logs/2024-01-01T12-00-00+00-00_my-task_abcd1234.eval"
+      );
+      assert.strictEqual(taskNameFromLog(uri), "my-task");
+    });
+
+    test("works for a nested posix path", () => {
+      const uri = Uri.file(
+        "/home/user/project/logs/2024-01-01T12-00-00+00-00_eval-task_x.eval"
+      );
+      assert.strictEqual(taskNameFromLog(uri), "eval-task");
+    });
+
+    test("handles a Windows-style file path", () => {
+      // The fragile split("/") approach failed on backslash-separated paths;
+      // basename() resolves the filename correctly regardless of separator.
+      const uri = Uri.file(
+        "C:\\Users\\me\\logs\\2024-01-01T12-00-00+00-00_win-task_y.eval"
+      );
+      assert.strictEqual(taskNameFromLog(uri), "win-task");
+    });
+
+    test("falls back to 'task' when there is no task segment", () => {
+      const uri = Uri.file("/logs/singletoken.eval");
+      assert.strictEqual(taskNameFromLog(uri), "task");
+    });
+
+    test("works for a remote (non-file) log URI", () => {
+      const uri = Uri.parse(
+        "s3://bucket/logs/2024-01-01T12-00-00+00-00_remote-task_z.eval"
+      );
+      assert.strictEqual(taskNameFromLog(uri), "remote-task");
+    });
+  });
+});


### PR DESCRIPTION
[lognotify.ts](src/providers/lognotify.ts) derived the eval-complete notification's task name with `e.log.path.split("/").pop()`, which is fragile for Windows-style (backslash) paths and ignores URI scheme differences.

Extracted a pure `taskNameFromLog()` helper that uses the existing separator- and scheme-aware `basename()` utility from [core/uri.ts](src/core/uri.ts), and covered it with tests: posix, nested, Windows-style, remote (`s3://`), and the no-task-segment fallback (`"task"`).

## Verification
`pnpm check` clean (lint + format + typecheck + 433 tests, incl. 5 new `taskNameFromLog` tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)