### PR TITLE
fix: make detectShellKind fallback test platform-aware

### DIFF
--- a/src/test/suite/shell-quote.test.ts
+++ b/src/test/suite/shell-quote.test.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import * as os from "os";
 
 import {
   detectShellKind,
@@ -39,9 +40,12 @@ suite("Shell Quote Test Suite", () => {
       );
     });
 
-    test("falls back to posix on non-win32 when unknown", () => {
-      // On the test host (darwin/linux) an unknown/undefined shell is posix.
-      assert.strictEqual(detectShellKind(undefined), "posix");
+    test("falls back to the platform default when the shell is unknown", () => {
+      // An unknown/undefined shell falls back to the platform default:
+      // powershell on Windows, posix elsewhere.
+      const expected = os.platform() === "win32" ? "powershell" : "posix";
+      assert.strictEqual(detectShellKind(undefined), expected);
+      assert.strictEqual(detectShellKind("/some/unknown/shell"), expected);
     });
   });
 


### PR DESCRIPTION
## Problem

The Windows CI leg (added in #108) is failing on `main` — and therefore on every open PR built against it, including the release PR #93:

```
Shell Quote Test Suite
  detectShellKind
    1) falls back to posix on non-win32 when unknown
       AssertionError: Expected values to be strictly equal
```

The test (from #95) hard-coded `"posix"` as the expected fallback:

```ts
assert.strictEqual(detectShellKind(undefined), "posix");
```

But `detectShellKind` falls back to `"powershell"` on Windows (VS Code's modern default), so the assertion is wrong on the Windows runner. It only passed before because CI was Linux-only.

## Fix

Compute the expected fallback from `os.platform()`, matching the production behavior on both platforms, and also assert the unrecognized-path case:

```ts
const expected = os.platform() === "win32" ? "powershell" : "posix";
assert.strictEqual(detectShellKind(undefined), expected);
assert.strictEqual(detectShellKind("/some/unknown/shell"), expected);
```

## Verification

`pnpm check` clean locally (465 tests). This is the only host-dependent assertion in the shell-quote suite — the per-kind `quoteArg`/`quoteCommandLine` tests pass an explicit `kind`, and the path-based `detectShellKind` tests use fixed paths that classify the same on any host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)