### PR TITLE
fix: relativize log listing locations tolerantly (URI vs plain path)

### DIFF
--- a/src/providers/activity-bar/log-listing/log-listing.ts
+++ b/src/providers/activity-bar/log-listing/log-listing.ts
@@ -1,3 +1,5 @@
+import path from "path";
+
 import { format, isThisYear, isToday } from "date-fns";
 import { throttle } from "lodash";
 import vscode, {
@@ -12,7 +14,12 @@ import vscode, {
 
 import { ListingMRU } from "../../../core/listing-mru";
 import { log } from "../../../core/log";
-import { normalizeWindowsUri } from "../../../core/uri";
+import {
+  getRelativeUri,
+  isUri,
+  normalizeWindowsUri,
+  resolveToUri,
+} from "../../../core/uri";
 
 export type LogNode =
   | ({
@@ -43,6 +50,37 @@ export interface LogItem {
 export interface Logs {
   log_dir: string;
   items: LogItem[];
+}
+
+/**
+ * Computes a log-dir-relative path for a listing item location.
+ *
+ * Listings historically used an exact string-prefix strip, which assumes the
+ * server returns locations in exactly the same form as the requested log dir.
+ * That isn't guaranteed — e.g. scout returns plain absolute paths for local
+ * scan dirs even when the requested dir is a file:// URI — so fall back to
+ * URI-aware relativization when the string prefix doesn't match. Locations
+ * outside the log dir are returned unchanged.
+ */
+export function relativeLogPath(logDir: string, location: string): string {
+  const dirWithSlash = logDir.endsWith("/") ? logDir : `${logDir}/`;
+  if (location.startsWith(dirWithSlash)) {
+    return location.slice(dirWithSlash.length);
+  }
+  try {
+    if (isUri(location) || path.isAbsolute(location)) {
+      const relative = getRelativeUri(
+        resolveToUri(logDir),
+        resolveToUri(location)
+      );
+      if (relative !== null) {
+        return relative;
+      }
+    }
+  } catch {
+    // unparseable dir or location — leave the location unchanged
+  }
+  return location;
 }
 
 export class LogListing {
@@ -123,11 +161,9 @@ export class LogListing {
     try {
       const logs = await this.logsFetcher_(this.logDir_);
       if (logs) {
-        const log_dir = normalizeWindowsUri(
-          logs.log_dir.endsWith("/") ? logs.log_dir : `${logs.log_dir}/`
-        );
+        const log_dir = normalizeWindowsUri(logs.log_dir);
         for (const file of logs.items) {
-          file.name = normalizeWindowsUri(file.name).replace(`${log_dir}`, "");
+          file.name = relativeLogPath(log_dir, normalizeWindowsUri(file.name));
         }
         const tree = buildLogTree(logs.items);
         return tree;

--- a/src/test/suite/log-listing.test.ts
+++ b/src/test/suite/log-listing.test.ts
@@ -3,6 +3,8 @@
  */
 import * as assert from "assert";
 
+import { relativeLogPath } from "../../providers/activity-bar/log-listing/log-listing";
+
 /**
  * Mock LogItem for testing
  */
@@ -608,6 +610,87 @@ suite("LogListing Test Suite", () => {
       );
 
       assert.strictEqual(normalized, "2024-01-15T14:30:45-08:00");
+    });
+  });
+
+  suite("relativeLogPath", () => {
+    test("strips a file:// log dir prefix from a file:// location", () => {
+      assert.strictEqual(
+        relativeLogPath(
+          "file:///Users/me/project/scans",
+          "file:///Users/me/project/scans/scan_id=abc"
+        ),
+        "scan_id=abc"
+      );
+    });
+
+    test("strips a log dir that already ends with a slash", () => {
+      assert.strictEqual(
+        relativeLogPath(
+          "file:///Users/me/project/scans/",
+          "file:///Users/me/project/scans/scan_id=abc"
+        ),
+        "scan_id=abc"
+      );
+    });
+
+    test("strips an s3 log dir prefix from an s3 location", () => {
+      assert.strictEqual(
+        relativeLogPath(
+          "s3://bucket/scans",
+          "s3://bucket/scans/2024/scan_id=abc"
+        ),
+        "2024/scan_id=abc"
+      );
+    });
+
+    test("relativizes a plain absolute path against a file:// log dir", () => {
+      // scout's /api/v2/scans returns plain absolute paths for local scan
+      // dirs even when the requested dir is a file:// URI
+      assert.strictEqual(
+        relativeLogPath(
+          "file:///Users/me/project/scans",
+          "/Users/me/project/scans/scan_id=abc"
+        ),
+        "scan_id=abc"
+      );
+    });
+
+    test("relativizes a nested plain absolute path", () => {
+      assert.strictEqual(
+        relativeLogPath(
+          "file:///Users/me/project/scans",
+          "/Users/me/project/scans/2024/06/scan_id=abc"
+        ),
+        "2024/06/scan_id=abc"
+      );
+    });
+
+    test("tolerates percent-encoding differences between dir and location", () => {
+      assert.strictEqual(
+        relativeLogPath(
+          "file:///Users/me/my%20project/scans",
+          "file:///Users/me/my project/scans/scan_id=abc"
+        ),
+        "scan_id=abc"
+      );
+    });
+
+    test("leaves a location outside of the log dir unchanged", () => {
+      assert.strictEqual(
+        relativeLogPath(
+          "file:///Users/me/project/scans",
+          "/Users/me/elsewhere/scan_id=abc"
+        ),
+        "/Users/me/elsewhere/scan_id=abc"
+      );
+    });
+
+    test("leaves an already-relative location unchanged", () => {
+      assert.strictEqual(
+        relativeLogPath("file:///Users/me/project/scans", "2024/scan_id=abc"),
+        "2024/scan_id=abc"
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

The scans activity panel showed the full absolute folder hierarchy (`Users/…`) for a local `./scans` dir instead of paths relative to it.

Root cause is in scout, not this repo: since inspect_scout 0.4.36 (meridianlabs-ai/inspect_scout#437), `/api/v2/scans` returns plain absolute paths for local scan dirs even when the requested dir is a `file://` URI. The listing code derived tree names with `location.replace(log_dir, "")`, which silently does nothing when the forms differ. Fixed at the source in meridianlabs-ai/inspect_scout#464; this PR is the extension-side hardening so the tree no longer depends on the server echoing the exact string form of the requested dir.

## Fix

New `relativeLogPath()` helper in log-listing:

- anchors the historical prefix strip to the start of the location (the old `replace` matched anywhere)
- falls back to URI-aware relativization (`resolveToUri` + `getRelativeUri`) when the string prefix doesn't match, tolerating plain paths vs `file://` URIs and percent-encoding differences
- leaves locations outside the log dir (and already-relative names) unchanged

Applies to both the scans and eval-logs listings.

## Tests

8 new `relativeLogPath` cases in `log-listing.test.ts` (file://, trailing slash, s3, plain absolute paths, nesting, encoding differences, outside-dir, already-relative). `pnpm check` green (lint, format, typecheck, 473 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)