### PR TITLE
fix: harden script-tag nonce injection regex (CodeQL js/bad-tag-filter)

### DIFF
--- a/src/core/webview.ts
+++ b/src/core/webview.ts
@@ -79,10 +79,12 @@ Please update to a newer version of ${packageName} to view this content.
     const resourceUri = (path: string) =>
       panel.webview.asWebviewUri(Uri.joinPath(viewDirUri, path)).toString();
 
-    // nonces for scripts
+    // nonces for scripts. Match the `<script` start tag followed by a tag
+    // boundary (whitespace or `>`) so we don't accidentally match tags like
+    // `<scripting>`. Case-insensitive and covers all whitespace forms.
     indexHtml = indexHtml.replace(
-      /<script([ >])/g,
-      `<script nonce="${nonce}"$1`
+      /<script(?=[\s>])/gi,
+      (match) => `${match} nonce="${nonce}"`
     );
 
     // Determine whether this is the old index.html format (before bundling),


### PR DESCRIPTION
## Summary
Addresses CodeQL alert **#1** (`js/bad-tag-filter`, High) in `src/core/webview.ts`.

The nonce-injection regex `/<script([ >])/g` only matched `<script` followed by a space or `>`, and was case-sensitive. Tags delimited by tab/newline or in other casing would be missed and left without a nonce.

## Change
- Case-insensitive match with a `[\s>]` lookahead boundary (correctly excludes `<scripting>` and `</script>`)
- Callback preserves the original tag text instead of hardcoding lowercase `<script`

## Risk
Negligible exploitability — the regex runs over our **own bundled `index.html`**, not attacker input — but the filter was genuinely fragile. This is hardening.

## Verification
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean
- All 473 tests pass (incl. `getWebviewPanelHtml` and nonce suites)
- Ad-hoc regex matrix confirmed: `<script>`, `<script src=>`, tab/newline-delimited, and uppercase all get the nonce; `<scripting>` and `</script>` correctly excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)