### PR TITLE
Support more methods

### DIFF
--- a/src/core/jsonrpc.ts
+++ b/src/core/jsonrpc.ts
@@ -19,6 +19,8 @@ export const kMethodEvalSet = "eval_set";
 // `/api/user-info` endpoints.
 export const kMethodEditLog = "edit_log";
 export const kMethodGetUserInfo = "get_user_info";
+// Installed inspect / scout versions, forwarded from `/api/app-config`.
+export const kMethodAppConfig = "app_config";
 
 // constants for Scout json-rpc methods
 export const kMethodGetScans = "get_scans";

--- a/src/core/jsonrpc.ts
+++ b/src/core/jsonrpc.ts
@@ -21,6 +21,13 @@ export const kMethodEditLog = "edit_log";
 export const kMethodGetUserInfo = "get_user_info";
 // Installed inspect / scout versions, forwarded from `/api/app-config`.
 export const kMethodAppConfig = "app_config";
+// Transcript search, forwarded to the inspect view server's /api/scout/*
+// endpoints (inspect_scout's search router). Only reachable when scout is
+// installed (the viewer gates the search panel on a non-null scout version
+// from app_config).
+export const kMethodListSearches = "list_searches";
+export const kMethodPostSearch = "post_search";
+export const kMethodGetSearchResult = "get_search_result";
 
 // constants for Scout json-rpc methods
 export const kMethodGetScans = "get_scans";

--- a/src/providers/inspect/inspect-view-server.ts
+++ b/src/providers/inspect/inspect-view-server.ts
@@ -319,6 +319,28 @@ export class InspectViewServer extends PackageViewServer {
     return result.data;
   }
 
+  /**
+   * Installed inspect / scout versions, forwarded from `/api/app-config`.
+   * Older inspect_ai versions lack the endpoint (404) — return a placeholder
+   * so the viewer's startup config gate still resolves and renders.
+   */
+  public async getAppConfig(): Promise<string> {
+    const fallback = JSON.stringify({
+      inspect_version: "unknown",
+      scout_version: null,
+    });
+    if (!this.haveInspectEvalLogFormat()) {
+      return fallback;
+    }
+    const result = await this.api_json(
+      "/api/app-config",
+      "GET",
+      undefined,
+      (status) => (status === 404 ? fallback : undefined)
+    );
+    return result.data;
+  }
+
   public async logMessage(log_file: string, message?: string): Promise<void> {
     if (hasMinimumInspectVersion(kInspectLogMessageVersion)) {
       await this.api_json(

--- a/src/providers/inspect/inspect-view-server.ts
+++ b/src/providers/inspect/inspect-view-server.ts
@@ -28,6 +28,15 @@ import {
 const kNotFoundSignal = "NotFound";
 const kNotModifiedSignal = "NotModified";
 
+/**
+ * Base64url-encode a string (RFC 4648 §5: url-safe alphabet, no padding) to
+ * match the viewer's `encodeBase64Url` so transcript dirs round-trip through
+ * the scout search routes identically across the browser and vscode clients.
+ */
+function encodeBase64Url(value: string): string {
+  return Buffer.from(value, "utf-8").toString("base64url");
+}
+
 export class InspectViewServer extends PackageViewServer {
   constructor(context: ExtensionContext, inspectManager: PackageManager) {
     super(
@@ -339,6 +348,87 @@ export class InspectViewServer extends PackageViewServer {
       (status) => (status === 404 ? fallback : undefined)
     );
     return result.data;
+  }
+
+  /**
+   * Transcript search, forwarded to inspect_scout's search router (mounted by
+   * inspect_ai under `/api/scout/*`). These mirror the view server's HTTP
+   * client (`api-view-server.ts`): the transcript dir is base64url-encoded
+   * into the path and the transcript id is URL-encoded.
+   *
+   * Only reachable when scout is installed — the viewer gates the search panel
+   * on a non-null scout version from `/api/app-config`. When the underlying
+   * server is too old to host these routes the requests 404; `getSearchResult`
+   * treats that as "no result yet" (view-server parity) while the others
+   * surface the error.
+   */
+  public async listSearches(
+    search_type: string,
+    count: number
+  ): Promise<string> {
+    const params = new URLSearchParams();
+    params.append("type", search_type);
+    params.append("count", String(count));
+    return (await this.api_json(`/api/scout/searches?${params.toString()}`))
+      .data;
+  }
+
+  public async postSearch(
+    transcriptDir: string,
+    transcriptId: string,
+    request: unknown
+  ): Promise<string> {
+    const headers = new Headers({
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    });
+    const path =
+      `/api/scout/transcripts/${encodeBase64Url(transcriptDir)}` +
+      `/${encodeURIComponent(transcriptId)}/search`;
+    // POST carries a body, so use serverFetch (api()/api_json don't forward one)
+    // and map HTTP error codes onto the thrown Error's `code`, matching editLog.
+    const result = await this.serverFetch(
+      path,
+      "POST",
+      headers,
+      JSON.stringify(request)
+    );
+    if (result.status >= 400) {
+      const text = typeof result.data === "string" ? result.data : "";
+      const err = new Error(text || `HTTP ${result.status}`) as Error & {
+        code?: number;
+      };
+      err.code = result.status;
+      throw err;
+    }
+    return typeof result.data === "string" ? result.data : "";
+  }
+
+  public async getSearchResult(
+    transcriptDir: string,
+    transcriptId: string,
+    searchId: string,
+    scope: { events?: string; messages?: string } | undefined
+  ): Promise<string> {
+    const params = new URLSearchParams();
+    if (scope?.messages) {
+      params.set("messages", scope.messages);
+    }
+    if (scope?.events) {
+      params.set("events", scope.events);
+    }
+    const query = params.toString();
+    const path =
+      `/api/scout/transcripts/${encodeBase64Url(transcriptDir)}` +
+      `/${encodeURIComponent(transcriptId)}/searches/${encodeURIComponent(searchId)}` +
+      (query ? `?${query}` : "");
+    // A result that isn't ready yet is a 404; return the JSON literal `null`
+    // so the viewer reads it as "keep polling" rather than an error.
+    return (
+      await this.api_json(path, "GET", undefined, (status) =>
+        status === 404 ? "null" : undefined
+      )
+    ).data;
   }
 
   public async logMessage(log_file: string, message?: string): Promise<void> {

--- a/src/providers/logview/logview-panel.ts
+++ b/src/providers/logview/logview-panel.ts
@@ -2,6 +2,7 @@ import vscode, { ExtensionContext, Uri } from "vscode";
 
 import { Disposable } from "../../core/dispose";
 import {
+  kMethodAppConfig,
   kMethodEditLog,
   kMethodEvalLog,
   kMethodEvalLogBytes,
@@ -94,6 +95,7 @@ export class LogviewPanel extends Disposable {
           params[2] as string | undefined
         ),
       [kMethodGetUserInfo]: () => server_.getUserInfo(),
+      [kMethodAppConfig]: () => server_.getAppConfig(),
     });
 
     // serve post message api to webview

--- a/src/providers/logview/logview-panel.ts
+++ b/src/providers/logview/logview-panel.ts
@@ -102,11 +102,7 @@ export class LogviewPanel extends Disposable {
       [kMethodListSearches]: (params: unknown[]) =>
         server_.listSearches(params[0] as string, params[1] as number),
       [kMethodPostSearch]: (params: unknown[]) =>
-        server_.postSearch(
-          params[0] as string,
-          params[1] as string,
-          params[2]
-        ),
+        server_.postSearch(params[0] as string, params[1] as string, params[2]),
       [kMethodGetSearchResult]: (params: unknown[]) =>
         server_.getSearchResult(
           params[0] as string,

--- a/src/providers/logview/logview-panel.ts
+++ b/src/providers/logview/logview-panel.ts
@@ -11,9 +11,12 @@ import {
   kMethodEvalLogHeaders,
   kMethodEvalLogs,
   kMethodEvalLogSize,
+  kMethodGetSearchResult,
   kMethodGetUserInfo,
+  kMethodListSearches,
   kMethodLogMessage,
   kMethodPendingSamples,
+  kMethodPostSearch,
   kMethodSampleData,
   webviewPanelJsonRpcServer,
 } from "../../core/jsonrpc";
@@ -96,6 +99,21 @@ export class LogviewPanel extends Disposable {
         ),
       [kMethodGetUserInfo]: () => server_.getUserInfo(),
       [kMethodAppConfig]: () => server_.getAppConfig(),
+      [kMethodListSearches]: (params: unknown[]) =>
+        server_.listSearches(params[0] as string, params[1] as number),
+      [kMethodPostSearch]: (params: unknown[]) =>
+        server_.postSearch(
+          params[0] as string,
+          params[1] as string,
+          params[2]
+        ),
+      [kMethodGetSearchResult]: (params: unknown[]) =>
+        server_.getSearchResult(
+          params[0] as string,
+          params[1] as string,
+          params[2] as string,
+          params[3] as { events?: string; messages?: string } | undefined
+        ),
     });
 
     // serve post message api to webview


### PR DESCRIPTION
Inspect recently added an `/app-config` endpoint that tells Inspect's viewer the version of Inspect and Scout, if installed. The presence of a Scout version is used to gate the search functionality. The search functionality also involves a few new endpoints. These changes wired up the new endpoints.