### PR TITLE
Generic HTTP transport for Inspect

### DIFF
--- a/src/core/package/view-server.ts
+++ b/src/core/package/view-server.ts
@@ -12,6 +12,32 @@ import { shQuote } from "../../core/string";
 
 import { PackageManager } from "./manager";
 
+// Custom request/response types for JSON-RPC proxy communication.
+// We can't use fetch's Request/Response/Headers because:
+// - They're not serializable (contain methods, streams, etc.)
+// - Headers is a class, not Record<string, string>
+// - Response.body is ReadableStream, not string
+// - We need bodyEncoding to indicate base64 for binary data
+//
+// Limitations vs native fetch:
+// - No streaming: bodies must be fully buffered as strings
+// - Binary data requires base64 encoding (adds ~33% overhead)
+// - Multi-value headers (e.g. Set-Cookie) collapse to single string
+// - Large request bodies must fit in memory
+export interface HttpProxyRpcRequest {
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  path: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+export interface HttpProxyRpcResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: string | null;
+  bodyEncoding: "utf8" | "base64";
+}
+
 export class PackageViewServer implements Disposable {
   constructor(
     context: ExtensionContext,
@@ -105,6 +131,37 @@ export class PackageViewServer implements Disposable {
         ? await response.text()
         : new Uint8Array(await response.arrayBuffer()),
       headers: responseHeaders,
+    };
+  }
+
+  /**
+   * JSON-RPC handler that proxies a webview HTTP request to the backend view
+   * server. Used by both the Inspect and Scout webviews so new viewer
+   * endpoints need no extension changes.
+   */
+  public async proxyRpcRequest(
+    request: HttpProxyRpcRequest
+  ): Promise<HttpProxyRpcResponse> {
+    await this.ensureRunning();
+
+    const { status, headers, data } = await this.serverFetch(
+      request.path,
+      request.method,
+      new Headers(request.headers),
+      request.body
+    );
+
+    const responseHeaders: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      responseHeaders[key] = value;
+    });
+
+    return {
+      status,
+      headers: responseHeaders,
+      ...(data instanceof Uint8Array
+        ? { body: Buffer.from(data).toString("base64"), bodyEncoding: "base64" }
+        : { body: data, bodyEncoding: "utf8" }),
     };
   }
 

--- a/src/providers/logview/logview-panel.ts
+++ b/src/providers/logview/logview-panel.ts
@@ -155,12 +155,18 @@ export class LogviewPanel extends Disposable {
         )}</script>`
       : "";
 
+    // Advertise the generic http_request proxy to the viewer. Older extensions
+    // inject nothing, so the viewer falls back to the named-RPC API.
+    const capabilitiesScript = `<script id="inspect-host-capabilities" type="application/json">${JSON.stringify(
+      [kMethodHttpRequest]
+    )}</script>`;
+
     return getWebviewPanelHtml(
       viewDir,
       this.panel_,
       this.getExtensionVersion(),
       overrideCssPath,
-      stateScript,
+      stateScript + capabilitiesScript,
       "Inspect AI"
     );
   }

--- a/src/providers/logview/logview-panel.ts
+++ b/src/providers/logview/logview-panel.ts
@@ -13,6 +13,7 @@ import {
   kMethodEvalLogSize,
   kMethodGetSearchResult,
   kMethodGetUserInfo,
+  kMethodHttpRequest,
   kMethodListSearches,
   kMethodLogMessage,
   kMethodPendingSamples,
@@ -21,6 +22,7 @@ import {
   webviewPanelJsonRpcServer,
 } from "../../core/jsonrpc";
 import { log } from "../../core/log";
+import { HttpProxyRpcRequest } from "../../core/package/view-server";
 import {
   getWebviewPanelHtml,
   handleWebviewPanelOpenMessages,
@@ -110,6 +112,8 @@ export class LogviewPanel extends Disposable {
           params[2] as string,
           params[3] as { events?: string; messages?: string } | undefined
         ),
+      [kMethodHttpRequest]: async (params: unknown[]) =>
+        server_.proxyRpcRequest(params[0] as HttpProxyRpcRequest),
     });
 
     // serve post message api to webview

--- a/src/providers/scanview/scanview-panel.ts
+++ b/src/providers/scanview/scanview-panel.ts
@@ -9,16 +9,14 @@ import {
   kMethodHttpRequest,
   webviewPanelJsonRpcServer,
 } from "../../core/jsonrpc";
+import { HttpProxyRpcRequest } from "../../core/package/view-server";
 import {
   getWebviewPanelHtml,
   handleWebviewPanelOpenMessages,
 } from "../../core/webview";
 import { HostWebviewPanel } from "../../hooks";
 import { scoutViewPath } from "../../scout/props";
-import {
-  HttpProxyRpcRequest,
-  ScoutViewServer,
-} from "../scout/scout-view-server";
+import { ScoutViewServer } from "../scout/scout-view-server";
 
 import { RouteMessage } from "./scanview-message";
 

--- a/src/providers/scout/scout-view-server.ts
+++ b/src/providers/scout/scout-view-server.ts
@@ -6,32 +6,6 @@ import { AbsolutePath, toAbsolutePath } from "../../core/path";
 import { basename, dirname } from "../../core/uri";
 import { scoutBinPath } from "../../scout/props";
 
-// Custom request/response types for JSON-RPC proxy communication.
-// We can't use fetch's Request/Response/Headers because:
-// - They're not serializable (contain methods, streams, etc.)
-// - Headers is a class, not Record<string, string>
-// - Response.body is ReadableStream, not string
-// - We need bodyEncoding to indicate base64 for binary data
-//
-// Limitations vs native fetch:
-// - No streaming: bodies must be fully buffered as strings
-// - Binary data requires base64 encoding (adds ~33% overhead)
-// - Multi-value headers (e.g. Set-Cookie) collapse to single string
-// - Large request bodies must fit in memory
-export interface HttpProxyRpcRequest {
-  method: "GET" | "POST" | "PUT" | "DELETE";
-  path: string;
-  headers?: Record<string, string>;
-  body?: string;
-}
-
-export interface HttpProxyRpcResponse {
-  status: number;
-  headers: Record<string, string>;
-  body: string | null;
-  bodyEncoding: "utf8" | "base64";
-}
-
 export class ScoutViewServer extends PackageViewServer {
   public readonly legacy: {
     getScans: (results_dir?: Uri) => Promise<string>;
@@ -154,41 +128,5 @@ export class ScoutViewServer extends PackageViewServer {
     return (
       await this.api_json(`/api/v2/scans/${base64Dir}/${scanFile}`, "DELETE")
     ).data;
-  }
-
-  /**
-   * JSON-RPC method handler that proxies webview HTTP requests to the backend.
-   * Converts HttpProxyRpcRequest to fetch call, then serializes response for JSON-RPC transport.
-   */
-  async proxyRpcRequest(
-    request: HttpProxyRpcRequest
-  ): Promise<HttpProxyRpcResponse> {
-    await this.ensureRunning();
-
-    const { status, headers, data } = await this.serverFetch(
-      request.path,
-      request.method,
-      new Headers(request.headers),
-      request.body
-    );
-
-    const responseHeaders: Record<string, string> = {};
-    headers.forEach((value, key) => {
-      responseHeaders[key] = value;
-    });
-
-    return {
-      status,
-      headers: responseHeaders,
-      ...(data instanceof Uint8Array
-        ? {
-            body: Buffer.from(data).toString("base64"),
-            bodyEncoding: "base64",
-          }
-        : {
-            body: data,
-            bodyEncoding: "utf8",
-          }),
-    };
   }
 }


### PR DESCRIPTION
Scout has had this generic `http_request` transport that allows the viewer to make arbitrary requests to the server over the JSON-RPC proxy. However Inspect did not support such a thing, so changes like #121 are needed when Inspect's viewer wants to hit new endpoints.

These changes lift the existing `proxyRpcRequest` up and expose it to Inspect just like its been for Scout. This puts the vscode extension in a position to handle a client that wants to use this transport. Since the viewer's version is tied to Inspect's version and not the extension's version, we need to still support old methods for some time, but eventually, we can strip it out and rely only on `http_request`. The extension will advertise its capabilities, and the viewer can choose to use `http_request` when it's available. 