### PR TITLE
Scope viewer requests to host-selected files and directories

### DIFF
--- a/src/core/package/view-server.ts
+++ b/src/core/package/view-server.ts
@@ -9,8 +9,22 @@ import { AbsolutePath, activeWorkspacePath } from "../../core/path";
 import { findOpenPort } from "../../core/port";
 import { spawnProcess } from "../../core/process";
 import { shQuote } from "../../core/string";
+import { ViewPathScope } from "../../core/uri";
 
 import { PackageManager } from "./manager";
+
+export const kViewScopeHeader = "X-Inspect-View-Scope";
+export const kViewScopeKindHeader = "X-Inspect-View-Scope-Kind";
+
+export function addViewScopeHeaders(
+  headers: Headers,
+  scope?: ViewPathScope
+): void {
+  if (scope) {
+    headers.set(kViewScopeHeader, scope.uri.toString());
+    headers.set(kViewScopeKindHeader, scope.kind);
+  }
+}
 
 export class PackageViewServer implements Disposable {
   constructor(
@@ -38,13 +52,25 @@ export class PackageViewServer implements Disposable {
     );
   }
 
+  protected viewArgs(): string[] {
+    return this.viewArgs_;
+  }
+
   protected async api_json(
     path: string,
     method: "GET" | "POST" | "PUT" | "DELETE" = "GET",
     headers?: Record<string, string>,
-    handleError?: (status: number) => string | undefined
+    handleError?: (status: number) => string | undefined,
+    scope?: ViewPathScope
   ): Promise<{ data: string; headers: Headers }> {
-    const result = await this.api(path, method, headers, false, handleError);
+    const result = await this.api(
+      path,
+      method,
+      headers,
+      false,
+      handleError,
+      scope
+    );
     return {
       data: result.data as string,
       headers: result.headers,
@@ -53,9 +79,10 @@ export class PackageViewServer implements Disposable {
 
   protected async api_bytes(
     path: string,
-    method: "GET" | "POST" | "PUT" | "DELETE" = "GET"
+    method: "GET" | "POST" | "PUT" | "DELETE" = "GET",
+    scope?: ViewPathScope
   ): Promise<{ data: Uint8Array; headers: Headers }> {
-    const result = await this.api(path, method, {}, true);
+    const result = await this.api(path, method, {}, true, undefined, scope);
     return {
       data: result.data as Uint8Array,
       headers: result.headers,
@@ -70,7 +97,8 @@ export class PackageViewServer implements Disposable {
     path: string,
     method: "GET" | "POST" | "PUT" | "DELETE",
     headers: Headers,
-    body?: string
+    body?: string,
+    scope?: ViewPathScope
   ): Promise<{
     status: number;
     data: string | Uint8Array;
@@ -83,6 +111,7 @@ export class PackageViewServer implements Disposable {
     requestHeaders.set("Pragma", "no-cache");
     requestHeaders.set("Expires", "0");
     requestHeaders.set("Cache-Control", "no-cache");
+    addViewScopeHeaders(requestHeaders, scope);
 
     const response = await fetch(
       `http://localhost:${this.serverPort_}${path}`,
@@ -113,7 +142,8 @@ export class PackageViewServer implements Disposable {
     method: "GET" | "POST" | "PUT" | "DELETE" = "GET",
     headers: Record<string, string> = {},
     binary: boolean = false,
-    handleError?: (status: number) => string | undefined
+    handleError?: (status: number) => string | undefined,
+    scope?: ViewPathScope
   ): Promise<{ data: string | Uint8Array; headers: Headers }> {
     // ensure the server is started and ready
     await this.ensureRunning();
@@ -127,6 +157,10 @@ export class PackageViewServer implements Disposable {
       Expires: "0",
       ["Cache-Control"]: "no-cache",
     };
+    if (scope) {
+      headers[kViewScopeHeader] = scope.uri.toString();
+      headers[kViewScopeKindHeader] = scope.kind;
+    }
 
     // make request
     const response = await fetch(
@@ -210,7 +244,7 @@ export class PackageViewServer implements Disposable {
               "--port",
               String(this.serverPort_),
               ...(this.logLevel_ ? ["--log-level", this.logLevel_] : []),
-            ].concat(this.viewArgs_);
+            ].concat(this.viewArgs());
             this.serverProcess_ = spawnProcess(
               quote(inspect.path),
               args.map(quote),

--- a/src/core/package/view-server.ts
+++ b/src/core/package/view-server.ts
@@ -9,7 +9,7 @@ import { AbsolutePath, activeWorkspacePath } from "../../core/path";
 import { findOpenPort } from "../../core/port";
 import { spawnProcess } from "../../core/process";
 import { shQuote } from "../../core/string";
-import { ViewPathScope, viewPathUriString } from "../../core/uri";
+import { ViewPathScope, viewPathScopeLocation } from "../../core/uri";
 
 import { PackageManager } from "./manager";
 
@@ -21,7 +21,7 @@ export async function addViewScopeHeaders(
   scope?: ViewPathScope
 ): Promise<void> {
   if (scope) {
-    headers.set(kViewScopeHeader, viewPathUriString(await scope.canonicalUri));
+    headers.set(kViewScopeHeader, await viewPathScopeLocation(scope));
     headers.set(kViewScopeKindHeader, scope.kind);
   }
 }
@@ -217,7 +217,7 @@ export class PackageViewServer implements Disposable {
       ["Cache-Control"]: "no-cache",
     };
     if (scope) {
-      headers[kViewScopeHeader] = viewPathUriString(await scope.canonicalUri);
+      headers[kViewScopeHeader] = await viewPathScopeLocation(scope);
       headers[kViewScopeKindHeader] = scope.kind;
     }
 

--- a/src/core/package/view-server.ts
+++ b/src/core/package/view-server.ts
@@ -9,7 +9,7 @@ import { AbsolutePath, activeWorkspacePath } from "../../core/path";
 import { findOpenPort } from "../../core/port";
 import { spawnProcess } from "../../core/process";
 import { shQuote } from "../../core/string";
-import { ViewPathScope } from "../../core/uri";
+import { ViewPathScope, viewPathUriString } from "../../core/uri";
 
 import { PackageManager } from "./manager";
 
@@ -21,7 +21,7 @@ export async function addViewScopeHeaders(
   scope?: ViewPathScope
 ): Promise<void> {
   if (scope) {
-    headers.set(kViewScopeHeader, (await scope.canonicalUri).toString());
+    headers.set(kViewScopeHeader, viewPathUriString(await scope.canonicalUri));
     headers.set(kViewScopeKindHeader, scope.kind);
   }
 }
@@ -217,7 +217,7 @@ export class PackageViewServer implements Disposable {
       ["Cache-Control"]: "no-cache",
     };
     if (scope) {
-      headers[kViewScopeHeader] = (await scope.canonicalUri).toString();
+      headers[kViewScopeHeader] = viewPathUriString(await scope.canonicalUri);
       headers[kViewScopeKindHeader] = scope.kind;
     }
 

--- a/src/core/package/view-server.ts
+++ b/src/core/package/view-server.ts
@@ -16,12 +16,12 @@ import { PackageManager } from "./manager";
 export const kViewScopeHeader = "X-Inspect-View-Scope";
 export const kViewScopeKindHeader = "X-Inspect-View-Scope-Kind";
 
-export function addViewScopeHeaders(
+export async function addViewScopeHeaders(
   headers: Headers,
   scope?: ViewPathScope
-): void {
+): Promise<void> {
   if (scope) {
-    headers.set(kViewScopeHeader, scope.uri.toString());
+    headers.set(kViewScopeHeader, (await scope.canonicalUri).toString());
     headers.set(kViewScopeKindHeader, scope.kind);
   }
 }
@@ -111,7 +111,7 @@ export class PackageViewServer implements Disposable {
     requestHeaders.set("Pragma", "no-cache");
     requestHeaders.set("Expires", "0");
     requestHeaders.set("Cache-Control", "no-cache");
-    addViewScopeHeaders(requestHeaders, scope);
+    await addViewScopeHeaders(requestHeaders, scope);
 
     const response = await fetch(
       `http://localhost:${this.serverPort_}${path}`,
@@ -158,7 +158,7 @@ export class PackageViewServer implements Disposable {
       ["Cache-Control"]: "no-cache",
     };
     if (scope) {
-      headers[kViewScopeHeader] = scope.uri.toString();
+      headers[kViewScopeHeader] = (await scope.canonicalUri).toString();
       headers[kViewScopeKindHeader] = scope.kind;
     }
 

--- a/src/core/uri.ts
+++ b/src/core/uri.ts
@@ -1,4 +1,4 @@
-import { realpath } from "fs/promises";
+import { lstat, realpath } from "fs/promises";
 import * as os from "os";
 import path from "path";
 
@@ -9,14 +9,24 @@ export type ViewPathScopeKind = "directory" | "file";
 export interface ViewPathScope {
   kind: ViewPathScopeKind;
   uri: Uri;
+  canonicalUri: Promise<Uri>;
 }
 
 export function directoryViewPathScope(uri: Uri): ViewPathScope {
-  return { kind: "directory", uri };
+  return createViewPathScope("directory", uri);
 }
 
 export function fileViewPathScope(uri: Uri): ViewPathScope {
-  return { kind: "file", uri };
+  return createViewPathScope("file", uri);
+}
+
+export function viewPathScopesEqual(
+  left: ViewPathScope,
+  right: ViewPathScope
+): boolean {
+  return (
+    left.kind === right.kind && left.uri.toString() === right.uri.toString()
+  );
 }
 
 export async function assertPathInViewScope(
@@ -38,26 +48,21 @@ export async function pathIsInViewScope(
 ): Promise<boolean> {
   const candidateUri = resolveViewPathCandidate(scope, candidate);
   if (scope.uri.scheme === "file") {
-    if (candidateUri.scheme !== "file") {
+    const [scopeUri, candidatePath] = await Promise.all([
+      scope.canonicalUri,
+      canonicalLocalPath(candidateUri),
+    ]);
+    if (!candidatePath) {
       return false;
     }
-    try {
-      const [scopePath, candidatePath] = await Promise.all([
-        realpath(scope.uri.fsPath),
-        realpath(candidateUri.fsPath),
-      ]);
-      if (scope.kind === "file") {
-        return (
-          normalizeLocalPath(candidatePath) === normalizeLocalPath(scopePath)
-        );
-      }
-      return localPathContains(scopePath, candidatePath);
-    } catch {
-      return false;
+    const scopePath = scopeUri.fsPath;
+    if (scope.kind === "file") {
+      return localPathsEqual(candidatePath, scopePath);
     }
+    return localPathContains(scopePath, candidatePath);
   }
 
-  const scopeRemote = canonicalRemoteUri(scope.uri);
+  const scopeRemote = canonicalRemoteUri(await scope.canonicalUri);
   const candidateRemote = canonicalRemoteUri(candidateUri);
   if (!scopeRemote || !candidateRemote) {
     return false;
@@ -75,7 +80,14 @@ export async function pathIsInViewScope(
     return false;
   }
   if (scope.kind === "file") {
-    return candidateRemote.path === scopeRemote.path;
+    // Signed URL queries are part of the exact-file capability.
+    return (
+      candidateRemote.path === scopeRemote.path &&
+      candidateRemote.query === scopeRemote.query
+    );
+  }
+  if (scopeRemote.query || candidateRemote.query) {
+    return false;
   }
   return remotePathContains(scopeRemote.path, candidateRemote.path);
 }
@@ -95,9 +107,118 @@ export function resolveViewPathCandidate(
     : Uri.joinPath(scope.uri, candidate);
 }
 
+function createViewPathScope(kind: ViewPathScopeKind, uri: Uri): ViewPathScope {
+  if (uri.scheme === "file") {
+    let canonicalUri: Promise<Uri> | undefined;
+    return {
+      kind,
+      uri,
+      get canonicalUri() {
+        canonicalUri ??= canonicalLocalPath(uri).then((canonicalPath) => {
+          if (!canonicalPath) {
+            throw new Error(`Invalid viewer ${kind} scope: ${uri.toString()}`);
+          }
+          return Uri.file(canonicalPath);
+        });
+        return canonicalUri;
+      },
+    };
+  }
+
+  const remote = canonicalRemoteUri(uri);
+  let canonicalUri = remote
+    ? uri.with({
+        scheme: remote.scheme,
+        authority: remote.authority,
+        path: remote.path,
+        query: remote.query,
+        fragment: "",
+      })
+    : null;
+  if (
+    kind === "directory" &&
+    remote &&
+    (remote.query || remote.scheme === "http" || remote.scheme === "https")
+  ) {
+    canonicalUri = null;
+  }
+  if (!canonicalUri) {
+    throw new Error(`Invalid viewer ${kind} scope: ${uri.toString()}`);
+  }
+  return { kind, uri, canonicalUri: Promise.resolve(canonicalUri) };
+}
+
+async function canonicalLocalPath(uri: Uri): Promise<string | null> {
+  if (
+    uri.scheme !== "file" ||
+    uri.query ||
+    uri.fragment ||
+    !isSupportedLocalFileAuthority(uri.authority)
+  ) {
+    return null;
+  }
+  return await realpathAllowMissing(uri.fsPath);
+}
+
+function isSupportedLocalFileAuthority(authority: string): boolean {
+  if (!authority || authority.toLowerCase() === "localhost") {
+    return true;
+  }
+  return (
+    os.platform() === "win32" &&
+    !authority.includes("@") &&
+    !authority.includes(":")
+  );
+}
+
+async function realpathAllowMissing(value: string): Promise<string | null> {
+  let current = path.resolve(value);
+  const missing: string[] = [];
+
+  while (true) {
+    try {
+      return path.join(await realpath(current), ...missing);
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") {
+        return null;
+      }
+    }
+
+    try {
+      if ((await lstat(current)).isSymbolicLink()) {
+        return null;
+      }
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") {
+        return null;
+      }
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    missing.unshift(path.basename(current));
+    current = parent;
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  return error instanceof Error && "code" in error
+    ? String((error as NodeJS.ErrnoException).code)
+    : undefined;
+}
+
 function normalizeLocalPath(value: string): string {
   const normalized = path.normalize(value);
   return os.platform() === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function localPathsEqual(left: string, right: string): boolean {
+  return (
+    normalizeLocalPath(path.resolve(left)) ===
+    normalizeLocalPath(path.resolve(right))
+  );
 }
 
 function localPathContains(parent: string, child: string): boolean {
@@ -117,16 +238,11 @@ interface CanonicalRemoteUri {
   scheme: string;
   authority: string;
   path: string;
+  query: string;
 }
 
 function canonicalRemoteUri(uri: Uri): CanonicalRemoteUri | null {
-  if (
-    !uri.scheme ||
-    uri.scheme === "file" ||
-    !uri.authority ||
-    uri.query ||
-    uri.fragment
-  ) {
+  if (!uri.scheme || uri.scheme === "file" || !uri.authority || uri.fragment) {
     return null;
   }
   let decodedPath: string;
@@ -142,6 +258,7 @@ function canonicalRemoteUri(uri: Uri): CanonicalRemoteUri | null {
     scheme: uri.scheme.toLowerCase(),
     authority: uri.authority.toLowerCase(),
     path: path.posix.normalize(`/${decodedPath.replace(/^\/+/, "")}`),
+    query: uri.query,
   };
 }
 

--- a/src/core/uri.ts
+++ b/src/core/uri.ts
@@ -25,27 +25,43 @@ export function viewPathScopesEqual(
   right: ViewPathScope
 ): boolean {
   return (
-    left.kind === right.kind && left.uri.toString() === right.uri.toString()
+    left.kind === right.kind &&
+    viewPathUriString(left.uri) === viewPathUriString(right.uri)
   );
+}
+
+export function viewPathUriString(uri: Uri): string {
+  const base = uri.with({ query: "", fragment: "" }).toString();
+  const query = canonicalRemoteQuery(uri.query);
+  return query ? `${base}?${query}` : base;
 }
 
 export async function assertPathInViewScope(
   scope: ViewPathScope,
   candidate: string | Uri
-): Promise<void> {
-  if (!(await pathIsInViewScope(scope, candidate))) {
+): Promise<Uri> {
+  const resolved = await resolvePathInViewScope(scope, candidate);
+  if (!resolved) {
     const location =
       typeof candidate === "string" ? candidate : candidate.toString();
     throw new Error(
       `Viewer path is outside the selected ${scope.kind} scope: ${location}`
     );
   }
+  return resolved;
 }
 
 export async function pathIsInViewScope(
   scope: ViewPathScope,
   candidate: string | Uri
 ): Promise<boolean> {
+  return (await resolvePathInViewScope(scope, candidate)) !== null;
+}
+
+export async function resolvePathInViewScope(
+  scope: ViewPathScope,
+  candidate: string | Uri
+): Promise<Uri | null> {
   const candidateUri = resolveViewPathCandidate(scope, candidate);
   if (scope.uri.scheme === "file") {
     const [scopeUri, candidatePath] = await Promise.all([
@@ -53,43 +69,56 @@ export async function pathIsInViewScope(
       canonicalLocalPath(candidateUri),
     ]);
     if (!candidatePath) {
-      return false;
+      return null;
     }
     const scopePath = scopeUri.fsPath;
     if (scope.kind === "file") {
-      return localPathsEqual(candidatePath, scopePath);
+      return localPathsEqual(candidatePath, scopePath)
+        ? Uri.file(candidatePath)
+        : null;
     }
-    return localPathContains(scopePath, candidatePath);
+    return localPathContains(scopePath, candidatePath)
+      ? Uri.file(candidatePath)
+      : null;
   }
 
   const scopeRemote = canonicalRemoteUri(await scope.canonicalUri);
   const candidateRemote = canonicalRemoteUri(candidateUri);
   if (!scopeRemote || !candidateRemote) {
-    return false;
+    return null;
   }
   if (
     scopeRemote.scheme !== candidateRemote.scheme ||
     scopeRemote.authority !== candidateRemote.authority
   ) {
-    return false;
+    return null;
   }
   if (
     scope.kind === "directory" &&
     (scopeRemote.scheme === "http" || scopeRemote.scheme === "https")
   ) {
-    return false;
+    return null;
   }
+  const resolved = candidateUri.with({
+    scheme: candidateRemote.scheme,
+    authority: candidateRemote.authority,
+    path: candidateRemote.path,
+    query: candidateUri.query,
+    fragment: "",
+  });
   if (scope.kind === "file") {
     // Signed URL queries are part of the exact-file capability.
-    return (
-      candidateRemote.path === scopeRemote.path &&
+    return candidateRemote.path === scopeRemote.path &&
       candidateRemote.query === scopeRemote.query
-    );
+      ? resolved
+      : null;
   }
   if (scopeRemote.query || candidateRemote.query) {
-    return false;
+    return null;
   }
-  return remotePathContains(scopeRemote.path, candidateRemote.path);
+  return remotePathContains(scopeRemote.path, candidateRemote.path)
+    ? resolved
+    : null;
 }
 
 export function resolveViewPathCandidate(
@@ -131,7 +160,7 @@ function createViewPathScope(kind: ViewPathScopeKind, uri: Uri): ViewPathScope {
         scheme: remote.scheme,
         authority: remote.authority,
         path: remote.path,
-        query: remote.query,
+        query: uri.query,
         fragment: "",
       })
     : null;
@@ -264,8 +293,32 @@ function canonicalRemoteUri(uri: Uri): CanonicalRemoteUri | null {
     scheme: uri.scheme.toLowerCase(),
     authority: uri.authority.toLowerCase(),
     path: path.posix.normalize(`/${decodedPath.replace(/^\/+/, "")}`),
-    query: uri.query,
+    query: canonicalRemoteQuery(uri.query),
   };
+}
+
+function canonicalRemoteQuery(query: string): string {
+  if (!query) {
+    return "";
+  }
+
+  const encode = (value: string) =>
+    encodeURIComponent(value).replace(
+      /[!'()*]/g,
+      (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+    );
+
+  return query
+    .split("&")
+    .map((field) => {
+      const separator = field.indexOf("=");
+      return separator === -1
+        ? encode(field)
+        : `${encode(field.slice(0, separator))}=${encode(
+            field.slice(separator + 1)
+          )}`;
+    })
+    .join("&");
 }
 
 function remotePathContains(parent: string, child: string): boolean {

--- a/src/core/uri.ts
+++ b/src/core/uri.ts
@@ -10,14 +10,20 @@ export interface ViewPathScope {
   kind: ViewPathScopeKind;
   uri: Uri;
   canonicalUri: Promise<Uri>;
+  opaqueLocation?: string;
+  canonical?: boolean;
 }
 
 export function directoryViewPathScope(uri: Uri): ViewPathScope {
   return createViewPathScope("directory", uri);
 }
 
-export function fileViewPathScope(uri: Uri): ViewPathScope {
-  return createViewPathScope("file", uri);
+export function fileViewPathScope(
+  uri: Uri,
+  opaqueLocation?: string,
+  canonicalLocation?: string
+): ViewPathScope {
+  return createViewPathScope("file", uri, opaqueLocation, canonicalLocation);
 }
 
 export function viewPathScopesEqual(
@@ -26,8 +32,73 @@ export function viewPathScopesEqual(
 ): boolean {
   return (
     left.kind === right.kind &&
-    viewPathUriString(left.uri) === viewPathUriString(right.uri)
+    !!left.canonical === !!right.canonical &&
+    (left.opaqueLocation ?? viewPathUriString(left.uri)) ===
+      (right.opaqueLocation ?? viewPathUriString(right.uri))
   );
+}
+
+const kViewPathLocationFragment = "inspect-view-location=";
+const kCanonicalViewPathLocationFragment = "inspect-view-canonical-location=";
+
+export function withViewPathLocation(uri: Uri, location: string): Uri {
+  return isOpaqueHttpViewLocation(location)
+    ? uri.with({
+        fragment:
+          kViewPathLocationFragment +
+          Buffer.from(location, "utf-8").toString("base64url"),
+      })
+    : uri;
+}
+
+export function viewPathLocationFromUri(uri: Uri): string | undefined {
+  if (!uri.fragment.startsWith(kViewPathLocationFragment)) {
+    return undefined;
+  }
+  try {
+    return Buffer.from(
+      uri.fragment.slice(kViewPathLocationFragment.length),
+      "base64url"
+    ).toString("utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+export function withCanonicalViewPathLocation(uri: Uri, location: string): Uri {
+  return uri.with({
+    fragment:
+      kCanonicalViewPathLocationFragment +
+      Buffer.from(location, "utf-8").toString("base64url"),
+  });
+}
+
+export function canonicalViewPathLocationFromUri(uri: Uri): string | undefined {
+  if (!uri.fragment.startsWith(kCanonicalViewPathLocationFragment)) {
+    return undefined;
+  }
+  try {
+    return Buffer.from(
+      uri.fragment.slice(kCanonicalViewPathLocationFragment.length),
+      "base64url"
+    ).toString("utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+export function isOpaqueHttpViewLocation(location: string): boolean {
+  try {
+    const parsed = new URL(location);
+    return (
+      (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+      !parsed.hash &&
+      !parsed.username &&
+      !parsed.password
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function viewPathUriString(uri: Uri): string {
@@ -62,6 +133,20 @@ export async function resolvePathInViewScope(
   scope: ViewPathScope,
   candidate: string | Uri
 ): Promise<Uri | null> {
+  if (scope.opaqueLocation) {
+    if (
+      candidate instanceof Uri &&
+      candidate.toString() === scope.uri.toString()
+    ) {
+      return scope.uri;
+    }
+    const candidateLocation =
+      typeof candidate === "string"
+        ? candidate
+        : (viewPathLocationFromUri(candidate) ?? viewPathUriString(candidate));
+    return candidateLocation === scope.opaqueLocation ? scope.uri : null;
+  }
+
   const candidateUri = resolveViewPathCandidate(scope, candidate);
   if (scope.uri.scheme === "file") {
     const [scopeUri, candidatePath] = await Promise.all([
@@ -121,6 +206,20 @@ export async function resolvePathInViewScope(
     : null;
 }
 
+export async function viewPathScopeLocation(
+  scope: ViewPathScope
+): Promise<string> {
+  return scope.opaqueLocation ?? viewPathUriString(await scope.canonicalUri);
+}
+
+export async function resolveViewPathLocation(
+  scope: ViewPathScope,
+  candidate: string | Uri
+): Promise<string> {
+  const resolved = await assertPathInViewScope(scope, candidate);
+  return scope.opaqueLocation ?? viewPathUriString(resolved);
+}
+
 export function resolveViewPathCandidate(
   scope: ViewPathScope,
   candidate: string | Uri
@@ -136,7 +235,46 @@ export function resolveViewPathCandidate(
     : Uri.joinPath(scope.uri, candidate);
 }
 
-function createViewPathScope(kind: ViewPathScopeKind, uri: Uri): ViewPathScope {
+function createViewPathScope(
+  kind: ViewPathScopeKind,
+  uri: Uri,
+  opaqueLocation?: string,
+  canonicalLocation?: string
+): ViewPathScope {
+  if (kind === "file" && canonicalLocation) {
+    if (viewPathUriString(uri) !== canonicalLocation) {
+      throw new Error(
+        `Canonical viewer file scope does not match: ${canonicalLocation}`
+      );
+    }
+    return {
+      kind,
+      uri,
+      canonicalUri: Promise.resolve(uri.with({ fragment: "" })),
+      canonical: true,
+    };
+  }
+
+  if (kind === "file" && opaqueLocation) {
+    if (!isOpaqueHttpViewLocation(opaqueLocation)) {
+      throw new Error(`Invalid viewer file scope: ${opaqueLocation}`);
+    }
+    const opaqueUri = Uri.parse(opaqueLocation);
+    if (
+      opaqueUri.scheme.toLowerCase() !== uri.scheme.toLowerCase() ||
+      opaqueUri.authority.toLowerCase() !== uri.authority.toLowerCase() ||
+      opaqueUri.path !== uri.path
+    ) {
+      throw new Error(`Viewer file scope does not match: ${opaqueLocation}`);
+    }
+    return {
+      kind,
+      uri,
+      canonicalUri: Promise.resolve(uri.with({ fragment: "" })),
+      opaqueLocation,
+    };
+  }
+
   if (uri.scheme === "file") {
     let canonicalUri: Promise<Uri> | undefined;
     return {

--- a/src/core/uri.ts
+++ b/src/core/uri.ts
@@ -1,7 +1,159 @@
+import { realpath } from "fs/promises";
 import * as os from "os";
 import path from "path";
 
 import { Uri } from "vscode";
+
+export type ViewPathScopeKind = "directory" | "file";
+
+export interface ViewPathScope {
+  kind: ViewPathScopeKind;
+  uri: Uri;
+}
+
+export function directoryViewPathScope(uri: Uri): ViewPathScope {
+  return { kind: "directory", uri };
+}
+
+export function fileViewPathScope(uri: Uri): ViewPathScope {
+  return { kind: "file", uri };
+}
+
+export async function assertPathInViewScope(
+  scope: ViewPathScope,
+  candidate: string | Uri
+): Promise<void> {
+  if (!(await pathIsInViewScope(scope, candidate))) {
+    const location =
+      typeof candidate === "string" ? candidate : candidate.toString();
+    throw new Error(
+      `Viewer path is outside the selected ${scope.kind} scope: ${location}`
+    );
+  }
+}
+
+export async function pathIsInViewScope(
+  scope: ViewPathScope,
+  candidate: string | Uri
+): Promise<boolean> {
+  const candidateUri = resolveViewPathCandidate(scope, candidate);
+  if (scope.uri.scheme === "file") {
+    if (candidateUri.scheme !== "file") {
+      return false;
+    }
+    try {
+      const [scopePath, candidatePath] = await Promise.all([
+        realpath(scope.uri.fsPath),
+        realpath(candidateUri.fsPath),
+      ]);
+      if (scope.kind === "file") {
+        return (
+          normalizeLocalPath(candidatePath) === normalizeLocalPath(scopePath)
+        );
+      }
+      return localPathContains(scopePath, candidatePath);
+    } catch {
+      return false;
+    }
+  }
+
+  const scopeRemote = canonicalRemoteUri(scope.uri);
+  const candidateRemote = canonicalRemoteUri(candidateUri);
+  if (!scopeRemote || !candidateRemote) {
+    return false;
+  }
+  if (
+    scopeRemote.scheme !== candidateRemote.scheme ||
+    scopeRemote.authority !== candidateRemote.authority
+  ) {
+    return false;
+  }
+  if (
+    scope.kind === "directory" &&
+    (scopeRemote.scheme === "http" || scopeRemote.scheme === "https")
+  ) {
+    return false;
+  }
+  if (scope.kind === "file") {
+    return candidateRemote.path === scopeRemote.path;
+  }
+  return remotePathContains(scopeRemote.path, candidateRemote.path);
+}
+
+export function resolveViewPathCandidate(
+  scope: ViewPathScope,
+  candidate: string | Uri
+): Uri {
+  if (candidate instanceof Uri) {
+    return candidate;
+  }
+  if (isUri(candidate) || path.isAbsolute(candidate)) {
+    return resolveToUri(candidate);
+  }
+  return scope.uri.scheme === "file"
+    ? Uri.file(path.resolve(scope.uri.fsPath, candidate))
+    : Uri.joinPath(scope.uri, candidate);
+}
+
+function normalizeLocalPath(value: string): string {
+  const normalized = path.normalize(value);
+  return os.platform() === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function localPathContains(parent: string, child: string): boolean {
+  const relative = path.relative(
+    normalizeLocalPath(parent),
+    normalizeLocalPath(child)
+  );
+  return (
+    relative === "" ||
+    (!relative.startsWith(`..${path.sep}`) &&
+      relative !== ".." &&
+      !path.isAbsolute(relative))
+  );
+}
+
+interface CanonicalRemoteUri {
+  scheme: string;
+  authority: string;
+  path: string;
+}
+
+function canonicalRemoteUri(uri: Uri): CanonicalRemoteUri | null {
+  if (
+    !uri.scheme ||
+    uri.scheme === "file" ||
+    !uri.authority ||
+    uri.query ||
+    uri.fragment
+  ) {
+    return null;
+  }
+  let decodedPath: string;
+  try {
+    decodedPath = decodeURIComponent(uri.path);
+  } catch {
+    return null;
+  }
+  if (decodedPath.includes("\\") || decodedPath.split("/").includes("..")) {
+    return null;
+  }
+  return {
+    scheme: uri.scheme.toLowerCase(),
+    authority: uri.authority.toLowerCase(),
+    path: path.posix.normalize(`/${decodedPath.replace(/^\/+/, "")}`),
+  };
+}
+
+function remotePathContains(parent: string, child: string): boolean {
+  const relative = path.posix.relative(parent, child);
+  return (
+    relative === "" ||
+    (!relative.startsWith("../") &&
+      relative !== ".." &&
+      !path.posix.isAbsolute(relative))
+  );
+}
 
 export function resolveToUri(pathOrUri: string): Uri {
   if (isUri(pathOrUri)) {
@@ -65,22 +217,40 @@ export function prettyUriPath(uri: Uri): string {
  * Returns null if child is not contained within parent
  */
 export function getRelativeUri(parentUri: Uri, childUri: Uri): string | null {
-  if (parentUri.scheme !== childUri.scheme) {
+  if (
+    parentUri.scheme.toLowerCase() !== childUri.scheme.toLowerCase() ||
+    parentUri.authority.toLowerCase() !== childUri.authority.toLowerCase()
+  ) {
     return null;
   }
 
-  const childStr = childUri.toString(true);
-  let parentStr = parentUri.toString(true);
-  if (childStr === parentStr) {
+  if (
+    parentUri.query ||
+    parentUri.fragment ||
+    childUri.query ||
+    childUri.fragment
+  ) {
     return null;
-  } else if (!childStr.startsWith(parentStr)) {
-    return null;
-  } else {
-    if (!parentStr.endsWith("/")) {
-      parentStr = `${parentStr}/`;
-    }
-    return childStr.slice(parentStr.length);
   }
+
+  const relative =
+    parentUri.scheme === "file"
+      ? path.relative(parentUri.fsPath, childUri.fsPath)
+      : path.posix.relative(
+          path.posix.normalize(parentUri.path),
+          path.posix.normalize(childUri.path)
+        );
+  if (
+    relative === "" ||
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    relative.startsWith("../") ||
+    path.isAbsolute(relative) ||
+    path.posix.isAbsolute(relative)
+  ) {
+    return null;
+  }
+  return relative.replaceAll(path.sep, "/");
 }
 
 export function normalizeWindowsUri(uri: string) {

--- a/src/core/uri.ts
+++ b/src/core/uri.ts
@@ -242,7 +242,13 @@ interface CanonicalRemoteUri {
 }
 
 function canonicalRemoteUri(uri: Uri): CanonicalRemoteUri | null {
-  if (!uri.scheme || uri.scheme === "file" || !uri.authority || uri.fragment) {
+  if (
+    !uri.scheme ||
+    uri.scheme === "file" ||
+    !uri.authority ||
+    uri.authority.includes("@") ||
+    uri.fragment
+  ) {
     return null;
   }
   let decodedPath: string;

--- a/src/providers/activity-bar/log-listing/log-listing-data.ts
+++ b/src/providers/activity-bar/log-listing/log-listing-data.ts
@@ -76,7 +76,7 @@ export class LogTreeDataProvider extends LogListingTreeDataProvider {
       treeItem.command = {
         command: "inspect.openLogViewer",
         title: "View Inspect Log",
-        arguments: [uri],
+        arguments: [uri, element.scope_location],
       };
     }
     return treeItem;

--- a/src/providers/activity-bar/log-listing/log-listing-data.ts
+++ b/src/providers/activity-bar/log-listing/log-listing-data.ts
@@ -4,6 +4,7 @@ import { TreeItem, TreeItemCollapsibleState } from "vscode";
 import * as vscode from "vscode";
 
 import { EvalLog } from "../../../@types/log";
+import { directoryViewPathScope } from "../../../core/uri";
 import { InspectViewServer } from "../../inspect/inspect-view-server";
 
 import {
@@ -86,11 +87,13 @@ export class LogTreeDataProvider extends LogListingTreeDataProvider {
       return Promise.resolve(item);
     }
 
-    const nodeUri = this.logListing_?.uriForNode(element);
-    if (nodeUri) {
-      const headers = await this.viewServer_.evalLogHeaders([
-        nodeUri.toString(),
-      ]);
+    const listing = this.logListing_;
+    const nodeUri = listing?.uriForNode(element);
+    if (listing && nodeUri) {
+      const headers = await this.viewServer_.evalLogHeaders(
+        [nodeUri.toString()],
+        directoryViewPathScope(listing.logDir())
+      );
       if (headers !== undefined) {
         const evalLog = (JSON.parse(headers) as EvalLog[])[0];
         if (evalLog && evalLog.version === 2) {

--- a/src/providers/activity-bar/log-listing/log-listing-data.ts
+++ b/src/providers/activity-bar/log-listing/log-listing-data.ts
@@ -92,7 +92,7 @@ export class LogTreeDataProvider extends LogListingTreeDataProvider {
     if (listing && nodeUri) {
       const headers = await this.viewServer_.evalLogHeaders(
         [nodeUri.toString()],
-        directoryViewPathScope(listing.logDir())
+        listing.pathScope() ?? directoryViewPathScope(listing.logDir())
       );
       if (headers !== undefined) {
         const evalLog = (JSON.parse(headers) as EvalLog[])[0];

--- a/src/providers/activity-bar/log-listing/log-listing-provider.ts
+++ b/src/providers/activity-bar/log-listing/log-listing-provider.ts
@@ -44,19 +44,18 @@ export async function activateLogListing(
   });
 
   // update the tree based on the current preferred log dir
-  const updateTree = () => {
+  const updateTree = async () => {
     // see what the active log dir is
     const preferredLogDir = context.workspaceState.get<string>(kLogListingDir);
     const logDir = preferredLogDir
       ? Uri.parse(preferredLogDir)
       : envManager.getDefaultLogDir();
+    const listingScope = directoryViewPathScope(logDir);
+    await listingScope.canonicalUri;
 
     // create a logs fetcher
     const logsFetcher = async (uri: Uri): Promise<Logs | undefined> => {
-      const logsJSON = await viewServer.evalLogs(
-        uri,
-        directoryViewPathScope(uri)
-      );
+      const logsJSON = await viewServer.evalLogs(uri, listingScope);
       if (logsJSON) {
         const logs = JSON.parse(logsJSON) as {
           log_dir: string;
@@ -83,7 +82,12 @@ export async function activateLogListing(
 
     // set it
     treeDataProvider.setLogListing(
-      new LogListing(logDir, new LogListingMRU(context), logsFetcher)
+      new LogListing(
+        logDir,
+        new LogListingMRU(context),
+        logsFetcher,
+        listingScope
+      )
     );
 
     // show a workspace relative path if this is in the workspace,
@@ -97,13 +101,13 @@ export async function activateLogListing(
   };
 
   // initial tree update
-  updateTree();
+  await updateTree();
 
   // update tree if the environment changes and we are tracking the workspace log dir
   disposables.push(
     envManager.onEnvironmentChanged(() => {
       if (context.workspaceState.get<string>(kLogListingDir) === undefined) {
-        updateTree();
+        void updateTree();
       }
     })
   );
@@ -120,7 +124,7 @@ export async function activateLogListing(
         );
 
         // trigger update
-        updateTree();
+        await updateTree();
 
         // reveal
         await revealLogListing();
@@ -154,7 +158,7 @@ export async function activateLogListing(
   // Register update command (for when the log directory changes )
   disposables.push(
     vscode.commands.registerCommand("inspect.logListingUpdate", () => {
-      updateTree();
+      void updateTree();
     })
   );
 
@@ -204,14 +208,13 @@ export async function activateLogListing(
           );
 
           if (result?.title === "Delete") {
-            const treeLogDir = treeDataProvider.getLogListing()?.logDir();
-            if (!treeLogDir) {
+            const listing = treeDataProvider.getLogListing();
+            const treeLogDir = listing?.logDir();
+            const scope = listing?.pathScope();
+            if (!treeLogDir || !scope) {
               return;
             }
-            await viewServer.evalLogDelete(
-              logUri.toString(),
-              directoryViewPathScope(treeLogDir)
-            );
+            await viewServer.evalLogDelete(logUri.toString(), scope);
             treeDataProvider.refresh();
           }
         }

--- a/src/providers/activity-bar/log-listing/log-listing-provider.ts
+++ b/src/providers/activity-bar/log-listing/log-listing-provider.ts
@@ -3,7 +3,11 @@ import { Uri } from "vscode";
 
 import { Command } from "../../../core/command";
 import { OutputWatcher } from "../../../core/package/output-watcher";
-import { getRelativeUri, prettyUriPath } from "../../../core/uri";
+import {
+  directoryViewPathScope,
+  getRelativeUri,
+  prettyUriPath,
+} from "../../../core/uri";
 import { activeWorkspaceFolder } from "../../../core/workspace";
 import { hasMinimumInspectVersion } from "../../../inspect/version";
 import { kInspectEvalLogFormatVersion } from "../../inspect/inspect-constants";
@@ -49,7 +53,10 @@ export async function activateLogListing(
 
     // create a logs fetcher
     const logsFetcher = async (uri: Uri): Promise<Logs | undefined> => {
-      const logsJSON = await viewServer.evalLogs(uri);
+      const logsJSON = await viewServer.evalLogs(
+        uri,
+        directoryViewPathScope(uri)
+      );
       if (logsJSON) {
         const logs = JSON.parse(logsJSON) as {
           log_dir: string;
@@ -197,7 +204,14 @@ export async function activateLogListing(
           );
 
           if (result?.title === "Delete") {
-            await viewServer.evalLogDelete(logUri.toString());
+            const treeLogDir = treeDataProvider.getLogListing()?.logDir();
+            if (!treeLogDir) {
+              return;
+            }
+            await viewServer.evalLogDelete(
+              logUri.toString(),
+              directoryViewPathScope(treeLogDir)
+            );
             treeDataProvider.refresh();
           }
         }

--- a/src/providers/activity-bar/log-listing/log-listing-provider.ts
+++ b/src/providers/activity-bar/log-listing/log-listing-provider.ts
@@ -15,7 +15,12 @@ import { InspectViewServer } from "../../inspect/inspect-view-server";
 import { WorkspaceEnvManager } from "../../workspace/workspace-env-provider";
 
 import { selectLogDirectory } from "./log-directory-selector";
-import { LogListing, LogNode, Logs } from "./log-listing";
+import {
+  filterLogItemsToViewScope,
+  LogListing,
+  LogNode,
+  Logs,
+} from "./log-listing";
 import { LogTreeDataProvider } from "./log-listing-data";
 import { LogListingMRU } from "./log-listing-mru";
 
@@ -66,14 +71,15 @@ export async function activateLogListing(
             task_id: string;
           }>;
         };
+        const items = logs.files.map((file) => ({
+          name: file.name,
+          mtime: file.mtime,
+          display_name: file.task,
+          item_id: file.task_id,
+        }));
         return {
           log_dir: logs.log_dir,
-          items: logs.files.map((file) => ({
-            name: file.name,
-            mtime: file.mtime,
-            display_name: file.task,
-            item_id: file.task_id,
-          })),
+          items: await filterLogItemsToViewScope(listingScope, items),
         };
       } else {
         return undefined;

--- a/src/providers/activity-bar/log-listing/log-listing-server-queue.ts
+++ b/src/providers/activity-bar/log-listing/log-listing-server-queue.ts
@@ -5,6 +5,7 @@ import { MarkdownString } from "vscode";
 import { stringify } from "yaml";
 
 import { EvalLog, EvalResults } from "../../../@types/log";
+import { directoryViewPathScope, ViewPathScope } from "../../../core/uri";
 import { sleep } from "../../../core/wait";
 
 import { LogListing, LogNode } from "./log-listing";
@@ -25,7 +26,10 @@ export class LogElementQueueProcessor {
 
   constructor(
     private readonly viewServer: {
-      evalLogHeaders: (uris: string[]) => Promise<string | undefined>;
+      evalLogHeaders: (
+        uris: string[],
+        scope: ViewPathScope
+      ) => Promise<string | undefined>;
     },
     private readonly logListing: () => LogListing | undefined,
     private readonly context: vscode.ExtensionContext,
@@ -98,7 +102,14 @@ export class LogElementQueueProcessor {
 
       if (uris.length > 0) {
         // Fetch headers
-        const headers = await this.viewServer.evalLogHeaders(uris);
+        const listing = this.logListing();
+        if (!listing) {
+          return;
+        }
+        const headers = await this.viewServer.evalLogHeaders(
+          uris,
+          directoryViewPathScope(listing.logDir())
+        );
 
         if (headers !== undefined) {
           const evalLogs = JSON.parse(headers) as EvalLog[];

--- a/src/providers/activity-bar/log-listing/log-listing-server-queue.ts
+++ b/src/providers/activity-bar/log-listing/log-listing-server-queue.ts
@@ -108,7 +108,7 @@ export class LogElementQueueProcessor {
         }
         const headers = await this.viewServer.evalLogHeaders(
           uris,
-          directoryViewPathScope(listing.logDir())
+          listing.pathScope() ?? directoryViewPathScope(listing.logDir())
         );
 
         if (headers !== undefined) {

--- a/src/providers/activity-bar/log-listing/log-listing.ts
+++ b/src/providers/activity-bar/log-listing/log-listing.ts
@@ -18,6 +18,7 @@ import {
   getRelativeUri,
   isUri,
   normalizeWindowsUri,
+  pathIsInViewScope,
   resolveToUri,
   ViewPathScope,
 } from "../../../core/uri";
@@ -51,6 +52,16 @@ export interface LogItem {
 export interface Logs {
   log_dir: string;
   items: LogItem[];
+}
+
+export async function filterLogItemsToViewScope(
+  scope: ViewPathScope,
+  items: LogItem[]
+): Promise<LogItem[]> {
+  const allowed = await Promise.all(
+    items.map((item) => pathIsInViewScope(scope, item.name))
+  );
+  return items.filter((_item, index) => allowed[index]);
 }
 
 /**

--- a/src/providers/activity-bar/log-listing/log-listing.ts
+++ b/src/providers/activity-bar/log-listing/log-listing.ts
@@ -19,6 +19,7 @@ import {
   isUri,
   normalizeWindowsUri,
   resolveToUri,
+  ViewPathScope,
 } from "../../../core/uri";
 
 export type LogNode =
@@ -87,11 +88,16 @@ export class LogListing {
   constructor(
     private readonly logDir_: Uri,
     private readonly mru_: ListingMRU,
-    private readonly logsFetcher_: (uri: Uri) => Promise<Logs | undefined>
+    private readonly logsFetcher_: (uri: Uri) => Promise<Logs | undefined>,
+    private readonly pathScope_?: ViewPathScope
   ) {}
 
   public logDir(): Uri {
     return this.logDir_;
+  }
+
+  public pathScope(): ViewPathScope | undefined {
+    return this.pathScope_;
   }
 
   public async ls(parent?: LogDirectory): Promise<LogNode[]> {

--- a/src/providers/activity-bar/log-listing/log-listing.ts
+++ b/src/providers/activity-bar/log-listing/log-listing.ts
@@ -18,9 +18,10 @@ import {
   getRelativeUri,
   isUri,
   normalizeWindowsUri,
-  pathIsInViewScope,
+  resolvePathInViewScope,
   resolveToUri,
   ViewPathScope,
+  viewPathUriString,
 } from "../../../core/uri";
 
 export type LogNode =
@@ -43,6 +44,7 @@ export interface LogDirectory {
 
 export interface LogItem {
   name: string;
+  scope_location?: string;
   mtime: number;
   display_name: string;
   item_id: string;
@@ -58,10 +60,15 @@ export async function filterLogItemsToViewScope(
   scope: ViewPathScope,
   items: LogItem[]
 ): Promise<LogItem[]> {
-  const allowed = await Promise.all(
-    items.map((item) => pathIsInViewScope(scope, item.name))
+  const resolved = await Promise.all(
+    items.map((item) => resolvePathInViewScope(scope, item.name))
   );
-  return items.filter((_item, index) => allowed[index]);
+  return items.flatMap((item, index) => {
+    const location = resolved[index];
+    return location
+      ? [{ ...item, scope_location: viewPathUriString(location) }]
+      : [];
+  });
 }
 
 /**
@@ -140,6 +147,9 @@ export class LogListing {
   }
 
   public uriForNode(node: LogNode) {
+    if (node.type === "file" && node.scope_location) {
+      return Uri.parse(node.scope_location);
+    }
     return Uri.joinPath(this.logDir_, node.name);
   }
 

--- a/src/providers/inspect/inspect-constants.ts
+++ b/src/providers/inspect/inspect-constants.ts
@@ -15,3 +15,4 @@ export const kInspectOpenInspectViewVersion = "0.3.16";
 export const kInspectMaxLogFileSizeVersion = "0.3.26";
 export const kInspectEvalLogFormatVersion = "0.3.43";
 export const kInspectLogMessageVersion = "0.3.105";
+export const kInspectScopedAuthorizationVersion = "0.3.242";

--- a/src/providers/inspect/inspect-view-server.ts
+++ b/src/providers/inspect/inspect-view-server.ts
@@ -11,11 +11,7 @@ import {
   activeWorkspacePath,
   toAbsolutePath,
 } from "../../core/path";
-import {
-  assertPathInViewScope,
-  ViewPathScope,
-  viewPathUriString,
-} from "../../core/uri";
+import { resolveViewPathLocation, ViewPathScope } from "../../core/uri";
 import { activeWorkspaceFolder } from "../../core/workspace";
 import {
   inspectEvalLog,
@@ -99,7 +95,7 @@ export class InspectViewServer extends PackageViewServer {
     clientFileCount: number,
     scope: ViewPathScope
   ): Promise<string | undefined> {
-    log_dir = viewPathUriString(await assertPathInViewScope(scope, log_dir));
+    log_dir = await resolveViewPathLocation(scope, log_dir);
     const log_file_token = (mtime: number, fileCount: number): string => {
       // Use a weak etag as the mtime and file count may not
       // uniquely identify the state of the log directory
@@ -135,11 +131,11 @@ export class InspectViewServer extends PackageViewServer {
     log_dir: Uri,
     scope: ViewPathScope
   ): Promise<string | undefined> {
-    log_dir = await assertPathInViewScope(scope, log_dir);
+    const resolvedLogDir = await resolveViewPathLocation(scope, log_dir);
     if (this.haveInspectEvalLogFormat()) {
       return (
         await this.api_json(
-          `/api/logs?log_dir=${encodeURIComponent(viewPathUriString(log_dir))}`,
+          `/api/logs?log_dir=${encodeURIComponent(resolvedLogDir)}`,
           "GET",
           undefined,
           undefined,
@@ -147,17 +143,20 @@ export class InspectViewServer extends PackageViewServer {
         )
       ).data;
     } else {
-      return evalLogs(log_dir);
+      return evalLogs(Uri.parse(resolvedLogDir));
     }
   }
 
-  public async evalLogsSolo(log_file: Uri): Promise<string> {
+  public async evalLogsSolo(
+    log_file: Uri,
+    scope: ViewPathScope
+  ): Promise<string> {
     if (this.haveInspectEvalLogFormat()) {
       await this.ensureRunning();
     }
     return JSON.stringify({
       log_dir: "",
-      files: [{ name: viewPathUriString(log_file) }],
+      files: [{ name: await resolveViewPathLocation(scope, log_file) }],
     });
   }
 
@@ -166,7 +165,7 @@ export class InspectViewServer extends PackageViewServer {
     headerOnly: boolean | number,
     scope: ViewPathScope
   ): Promise<string | undefined> {
-    file = viewPathUriString(await assertPathInViewScope(scope, file));
+    file = await resolveViewPathLocation(scope, file);
     if (this.haveInspectEvalLogFormat()) {
       return (
         await this.api_json(
@@ -186,7 +185,7 @@ export class InspectViewServer extends PackageViewServer {
     file: string,
     scope: ViewPathScope
   ): Promise<number> {
-    file = viewPathUriString(await assertPathInViewScope(scope, file));
+    file = await resolveViewPathLocation(scope, file);
     if (this.haveInspectEvalLogFormat()) {
       return Number(
         (
@@ -208,7 +207,7 @@ export class InspectViewServer extends PackageViewServer {
     file: string,
     scope: ViewPathScope
   ): Promise<number> {
-    file = viewPathUriString(await assertPathInViewScope(scope, file));
+    file = await resolveViewPathLocation(scope, file);
     if (this.haveInspectEvalLogFormat()) {
       return Number(
         (
@@ -232,7 +231,7 @@ export class InspectViewServer extends PackageViewServer {
     end: number,
     scope: ViewPathScope
   ): Promise<Uint8Array> {
-    file = viewPathUriString(await assertPathInViewScope(scope, file));
+    file = await resolveViewPathLocation(scope, file);
     if (this.haveInspectEvalLogFormat()) {
       return (
         await this.api_bytes(
@@ -251,9 +250,7 @@ export class InspectViewServer extends PackageViewServer {
     scope: ViewPathScope
   ): Promise<string | undefined> {
     files = await Promise.all(
-      files.map(async (file) =>
-        viewPathUriString(await assertPathInViewScope(scope, file))
-      )
+      files.map((file) => resolveViewPathLocation(scope, file))
     );
     if (this.haveInspectEvalLogFormat()) {
       const params = new URLSearchParams();
@@ -279,7 +276,7 @@ export class InspectViewServer extends PackageViewServer {
     etag: string | undefined,
     scope: ViewPathScope
   ): Promise<string | undefined> {
-    log_file = viewPathUriString(await assertPathInViewScope(scope, log_file));
+    log_file = await resolveViewPathLocation(scope, log_file);
     const params = new URLSearchParams();
     params.append("log", log_file);
 
@@ -317,7 +314,7 @@ export class InspectViewServer extends PackageViewServer {
     last_event?: number,
     last_attachment?: number
   ): Promise<string | undefined> {
-    log_file = viewPathUriString(await assertPathInViewScope(scope, log_file));
+    log_file = await resolveViewPathLocation(scope, log_file);
     // Url Params
     const params = new URLSearchParams();
     params.append("log", log_file);
@@ -366,7 +363,7 @@ export class InspectViewServer extends PackageViewServer {
     ifMatchEtag: string | undefined,
     scope: ViewPathScope
   ): Promise<string> {
-    file = viewPathUriString(await assertPathInViewScope(scope, file));
+    file = await resolveViewPathLocation(scope, file);
     if (!this.haveInspectEvalLogFormat()) {
       throw new Error("editLog not implemented");
     }
@@ -481,9 +478,7 @@ export class InspectViewServer extends PackageViewServer {
     request: unknown,
     scope: ViewPathScope
   ): Promise<string> {
-    transcriptDir = viewPathUriString(
-      await assertPathInViewScope(scope, transcriptDir)
-    );
+    transcriptDir = await resolveViewPathLocation(scope, transcriptDir);
     const headers = new Headers({
       "Content-Type": "application/json",
       Accept: "application/json",
@@ -518,9 +513,7 @@ export class InspectViewServer extends PackageViewServer {
     searchScope: { events?: string; messages?: string } | undefined,
     pathScope: ViewPathScope
   ): Promise<string> {
-    transcriptDir = viewPathUriString(
-      await assertPathInViewScope(pathScope, transcriptDir)
-    );
+    transcriptDir = await resolveViewPathLocation(pathScope, transcriptDir);
     const params = new URLSearchParams();
     if (searchScope?.messages) {
       params.set("messages", searchScope.messages);
@@ -551,7 +544,7 @@ export class InspectViewServer extends PackageViewServer {
     message: string | undefined,
     scope: ViewPathScope
   ): Promise<void> {
-    log_file = viewPathUriString(await assertPathInViewScope(scope, log_file));
+    log_file = await resolveViewPathLocation(scope, log_file);
     if (hasMinimumInspectVersion(kInspectLogMessageVersion)) {
       await this.api_json(
         `/api/log-message/${encodeURIComponent(log_file)}?message=${encodeURIComponent(

--- a/src/providers/inspect/inspect-view-server.ts
+++ b/src/providers/inspect/inspect-view-server.ts
@@ -11,7 +11,11 @@ import {
   activeWorkspacePath,
   toAbsolutePath,
 } from "../../core/path";
-import { assertPathInViewScope, ViewPathScope } from "../../core/uri";
+import {
+  assertPathInViewScope,
+  ViewPathScope,
+  viewPathUriString,
+} from "../../core/uri";
 import { activeWorkspaceFolder } from "../../core/workspace";
 import {
   inspectEvalLog,
@@ -95,7 +99,7 @@ export class InspectViewServer extends PackageViewServer {
     clientFileCount: number,
     scope: ViewPathScope
   ): Promise<string | undefined> {
-    await assertPathInViewScope(scope, log_dir);
+    log_dir = viewPathUriString(await assertPathInViewScope(scope, log_dir));
     const log_file_token = (mtime: number, fileCount: number): string => {
       // Use a weak etag as the mtime and file count may not
       // uniquely identify the state of the log directory
@@ -131,11 +135,11 @@ export class InspectViewServer extends PackageViewServer {
     log_dir: Uri,
     scope: ViewPathScope
   ): Promise<string | undefined> {
-    await assertPathInViewScope(scope, log_dir);
+    log_dir = await assertPathInViewScope(scope, log_dir);
     if (this.haveInspectEvalLogFormat()) {
       return (
         await this.api_json(
-          `/api/logs?log_dir=${encodeURIComponent(log_dir.toString())}`,
+          `/api/logs?log_dir=${encodeURIComponent(viewPathUriString(log_dir))}`,
           "GET",
           undefined,
           undefined,
@@ -153,7 +157,7 @@ export class InspectViewServer extends PackageViewServer {
     }
     return JSON.stringify({
       log_dir: "",
-      files: [{ name: log_file.toString(true) }],
+      files: [{ name: viewPathUriString(log_file) }],
     });
   }
 
@@ -162,7 +166,7 @@ export class InspectViewServer extends PackageViewServer {
     headerOnly: boolean | number,
     scope: ViewPathScope
   ): Promise<string | undefined> {
-    await assertPathInViewScope(scope, file);
+    file = viewPathUriString(await assertPathInViewScope(scope, file));
     if (this.haveInspectEvalLogFormat()) {
       return (
         await this.api_json(
@@ -182,7 +186,7 @@ export class InspectViewServer extends PackageViewServer {
     file: string,
     scope: ViewPathScope
   ): Promise<number> {
-    await assertPathInViewScope(scope, file);
+    file = viewPathUriString(await assertPathInViewScope(scope, file));
     if (this.haveInspectEvalLogFormat()) {
       return Number(
         (
@@ -204,7 +208,7 @@ export class InspectViewServer extends PackageViewServer {
     file: string,
     scope: ViewPathScope
   ): Promise<number> {
-    await assertPathInViewScope(scope, file);
+    file = viewPathUriString(await assertPathInViewScope(scope, file));
     if (this.haveInspectEvalLogFormat()) {
       return Number(
         (
@@ -228,7 +232,7 @@ export class InspectViewServer extends PackageViewServer {
     end: number,
     scope: ViewPathScope
   ): Promise<Uint8Array> {
-    await assertPathInViewScope(scope, file);
+    file = viewPathUriString(await assertPathInViewScope(scope, file));
     if (this.haveInspectEvalLogFormat()) {
       return (
         await this.api_bytes(
@@ -246,7 +250,11 @@ export class InspectViewServer extends PackageViewServer {
     files: string[],
     scope: ViewPathScope
   ): Promise<string | undefined> {
-    await Promise.all(files.map((file) => assertPathInViewScope(scope, file)));
+    files = await Promise.all(
+      files.map(async (file) =>
+        viewPathUriString(await assertPathInViewScope(scope, file))
+      )
+    );
     if (this.haveInspectEvalLogFormat()) {
       const params = new URLSearchParams();
       for (const file of files) {
@@ -271,7 +279,7 @@ export class InspectViewServer extends PackageViewServer {
     etag: string | undefined,
     scope: ViewPathScope
   ): Promise<string | undefined> {
-    await assertPathInViewScope(scope, log_file);
+    log_file = viewPathUriString(await assertPathInViewScope(scope, log_file));
     const params = new URLSearchParams();
     params.append("log", log_file);
 
@@ -309,7 +317,7 @@ export class InspectViewServer extends PackageViewServer {
     last_event?: number,
     last_attachment?: number
   ): Promise<string | undefined> {
-    await assertPathInViewScope(scope, log_file);
+    log_file = viewPathUriString(await assertPathInViewScope(scope, log_file));
     // Url Params
     const params = new URLSearchParams();
     params.append("log", log_file);
@@ -358,7 +366,7 @@ export class InspectViewServer extends PackageViewServer {
     ifMatchEtag: string | undefined,
     scope: ViewPathScope
   ): Promise<string> {
-    await assertPathInViewScope(scope, file);
+    file = viewPathUriString(await assertPathInViewScope(scope, file));
     if (!this.haveInspectEvalLogFormat()) {
       throw new Error("editLog not implemented");
     }
@@ -473,7 +481,9 @@ export class InspectViewServer extends PackageViewServer {
     request: unknown,
     scope: ViewPathScope
   ): Promise<string> {
-    await assertPathInViewScope(scope, transcriptDir);
+    transcriptDir = viewPathUriString(
+      await assertPathInViewScope(scope, transcriptDir)
+    );
     const headers = new Headers({
       "Content-Type": "application/json",
       Accept: "application/json",
@@ -508,7 +518,9 @@ export class InspectViewServer extends PackageViewServer {
     searchScope: { events?: string; messages?: string } | undefined,
     pathScope: ViewPathScope
   ): Promise<string> {
-    await assertPathInViewScope(pathScope, transcriptDir);
+    transcriptDir = viewPathUriString(
+      await assertPathInViewScope(pathScope, transcriptDir)
+    );
     const params = new URLSearchParams();
     if (searchScope?.messages) {
       params.set("messages", searchScope.messages);
@@ -539,7 +551,7 @@ export class InspectViewServer extends PackageViewServer {
     message: string | undefined,
     scope: ViewPathScope
   ): Promise<void> {
-    await assertPathInViewScope(scope, log_file);
+    log_file = viewPathUriString(await assertPathInViewScope(scope, log_file));
     if (hasMinimumInspectVersion(kInspectLogMessageVersion)) {
       await this.api_json(
         `/api/log-message/${encodeURIComponent(log_file)}?message=${encodeURIComponent(

--- a/src/providers/inspect/inspect-view-server.ts
+++ b/src/providers/inspect/inspect-view-server.ts
@@ -7,6 +7,7 @@ import {
   activeWorkspacePath,
   toAbsolutePath,
 } from "../../core/path";
+import { assertPathInViewScope, ViewPathScope } from "../../core/uri";
 import { activeWorkspaceFolder } from "../../core/workspace";
 import {
   inspectEvalLog,
@@ -23,6 +24,7 @@ import {
   kInspectEvalLogFormatVersion,
   kInspectLogMessageVersion,
   kInspectOpenInspectViewVersion,
+  kInspectScopedAuthorizationVersion,
 } from "./inspect-constants";
 
 const kNotFoundSignal = "NotFound";
@@ -52,6 +54,15 @@ export class InspectViewServer extends PackageViewServer {
     );
   }
 
+  protected override viewArgs(): string[] {
+    return [
+      ...super.viewArgs(),
+      ...(hasMinimumInspectVersion(kInspectScopedAuthorizationVersion)
+        ? ["--scoped-authorization"]
+        : []),
+    ];
+  }
+
   public async evalLogDir(): Promise<string | undefined> {
     if (this.haveInspectEvalLogFormat()) {
       return (await this.api_json(`/api/log-dir`)).data;
@@ -63,8 +74,10 @@ export class InspectViewServer extends PackageViewServer {
   public async evalLogFiles(
     log_dir: string,
     mtime: number,
-    clientFileCount: number
+    clientFileCount: number,
+    scope: ViewPathScope
   ): Promise<string | undefined> {
+    await assertPathInViewScope(scope, log_dir);
     const log_file_token = (mtime: number, fileCount: number): string => {
       // Use a weak etag as the mtime and file count may not
       // uniquely identify the state of the log directory
@@ -86,7 +99,9 @@ export class InspectViewServer extends PackageViewServer {
         await this.api_json(
           `/api/log-files?${params.toString()}`,
           "GET",
-          headers
+          headers,
+          undefined,
+          scope
         )
       ).data;
     } else {
@@ -94,11 +109,19 @@ export class InspectViewServer extends PackageViewServer {
     }
   }
 
-  public async evalLogs(log_dir: Uri): Promise<string | undefined> {
+  public async evalLogs(
+    log_dir: Uri,
+    scope: ViewPathScope
+  ): Promise<string | undefined> {
+    await assertPathInViewScope(scope, log_dir);
     if (this.haveInspectEvalLogFormat()) {
       return (
         await this.api_json(
-          `/api/logs?log_dir=${encodeURIComponent(log_dir.toString())}`
+          `/api/logs?log_dir=${encodeURIComponent(log_dir.toString())}`,
+          "GET",
+          undefined,
+          undefined,
+          scope
         )
       ).data;
     } else {
@@ -118,12 +141,18 @@ export class InspectViewServer extends PackageViewServer {
 
   public async evalLog(
     file: string,
-    headerOnly: boolean | number
+    headerOnly: boolean | number,
+    scope: ViewPathScope
   ): Promise<string | undefined> {
+    await assertPathInViewScope(scope, file);
     if (this.haveInspectEvalLogFormat()) {
       return (
         await this.api_json(
-          `/api/logs/${encodeURIComponent(file)}?header-only=${headerOnly}`
+          `/api/logs/${encodeURIComponent(file)}?header-only=${headerOnly}`,
+          "GET",
+          undefined,
+          undefined,
+          scope
         )
       ).data;
     } else {
@@ -131,21 +160,44 @@ export class InspectViewServer extends PackageViewServer {
     }
   }
 
-  public async evalLogSize(file: string): Promise<number> {
+  public async evalLogSize(
+    file: string,
+    scope: ViewPathScope
+  ): Promise<number> {
+    await assertPathInViewScope(scope, file);
     if (this.haveInspectEvalLogFormat()) {
       return Number(
-        (await this.api_json(`/api/log-size/${encodeURIComponent(file)}`)).data
+        (
+          await this.api_json(
+            `/api/log-size/${encodeURIComponent(file)}`,
+            "GET",
+            undefined,
+            undefined,
+            scope
+          )
+        ).data
       );
     } else {
       throw new Error("evalLogSize not implemented");
     }
   }
 
-  public async evalLogDelete(file: string): Promise<number> {
+  public async evalLogDelete(
+    file: string,
+    scope: ViewPathScope
+  ): Promise<number> {
+    await assertPathInViewScope(scope, file);
     if (this.haveInspectEvalLogFormat()) {
       return Number(
-        (await this.api_json(`/api/log-delete/${encodeURIComponent(file)}`))
-          .data
+        (
+          await this.api_json(
+            `/api/log-delete/${encodeURIComponent(file)}`,
+            "GET",
+            undefined,
+            undefined,
+            scope
+          )
+        ).data
       );
     } else {
       throw new Error("evalLogDelete not implemented");
@@ -155,12 +207,16 @@ export class InspectViewServer extends PackageViewServer {
   public async evalLogBytes(
     file: string,
     start: number,
-    end: number
+    end: number,
+    scope: ViewPathScope
   ): Promise<Uint8Array> {
+    await assertPathInViewScope(scope, file);
     if (this.haveInspectEvalLogFormat()) {
       return (
         await this.api_bytes(
-          `/api/log-bytes/${encodeURIComponent(file)}?start=${start}&end=${end}`
+          `/api/log-bytes/${encodeURIComponent(file)}?start=${start}&end=${end}`,
+          "GET",
+          scope
         )
       ).data;
     } else {
@@ -168,14 +224,25 @@ export class InspectViewServer extends PackageViewServer {
     }
   }
 
-  public async evalLogHeaders(files: string[]): Promise<string | undefined> {
+  public async evalLogHeaders(
+    files: string[],
+    scope: ViewPathScope
+  ): Promise<string | undefined> {
+    await Promise.all(files.map((file) => assertPathInViewScope(scope, file)));
     if (this.haveInspectEvalLogFormat()) {
       const params = new URLSearchParams();
       for (const file of files) {
         params.append("file", file);
       }
-      return (await this.api_json(`/api/log-headers?${params.toString()}`))
-        .data;
+      return (
+        await this.api_json(
+          `/api/log-headers?${params.toString()}`,
+          "GET",
+          undefined,
+          undefined,
+          scope
+        )
+      ).data;
     } else {
       return evalLogHeaders(files);
     }
@@ -183,8 +250,10 @@ export class InspectViewServer extends PackageViewServer {
 
   public async evalLogPendingSamples(
     log_file: string,
-    etag?: string
+    etag: string | undefined,
+    scope: ViewPathScope
   ): Promise<string | undefined> {
+    await assertPathInViewScope(scope, log_file);
     const params = new URLSearchParams();
     params.append("log", log_file);
 
@@ -208,7 +277,8 @@ export class InspectViewServer extends PackageViewServer {
         `/api/pending-samples?${params.toString()}`,
         "GET",
         headers,
-        handleError
+        handleError,
+        scope
       )
     ).data;
   }
@@ -217,9 +287,11 @@ export class InspectViewServer extends PackageViewServer {
     log_file: string,
     id: string | number,
     epoch: number,
+    scope: ViewPathScope,
     last_event?: number,
     last_attachment?: number
   ): Promise<string | undefined> {
+    await assertPathInViewScope(scope, log_file);
     // Url Params
     const params = new URLSearchParams();
     params.append("log", log_file);
@@ -246,7 +318,8 @@ export class InspectViewServer extends PackageViewServer {
         `/api/pending-sample-data?${params.toString()}`,
         "GET",
         {},
-        handleError
+        handleError,
+        scope
       )
     ).data;
   }
@@ -264,8 +337,10 @@ export class InspectViewServer extends PackageViewServer {
   public async editLog(
     file: string,
     update: unknown,
-    ifMatchEtag?: string
+    ifMatchEtag: string | undefined,
+    scope: ViewPathScope
   ): Promise<string> {
+    await assertPathInViewScope(scope, file);
     if (!this.haveInspectEvalLogFormat()) {
       throw new Error("editLog not implemented");
     }
@@ -281,7 +356,8 @@ export class InspectViewServer extends PackageViewServer {
       path,
       "POST",
       headers,
-      JSON.stringify(update)
+      JSON.stringify(update),
+      scope
     );
     if (result.status >= 400) {
       const text = typeof result.data === "string" ? result.data : "";
@@ -376,8 +452,10 @@ export class InspectViewServer extends PackageViewServer {
   public async postSearch(
     transcriptDir: string,
     transcriptId: string,
-    request: unknown
+    request: unknown,
+    scope: ViewPathScope
   ): Promise<string> {
+    await assertPathInViewScope(scope, transcriptDir);
     const headers = new Headers({
       "Content-Type": "application/json",
       Accept: "application/json",
@@ -391,7 +469,8 @@ export class InspectViewServer extends PackageViewServer {
       path,
       "POST",
       headers,
-      JSON.stringify(request)
+      JSON.stringify(request),
+      scope
     );
     if (result.status >= 400) {
       const text = typeof result.data === "string" ? result.data : "";
@@ -408,14 +487,16 @@ export class InspectViewServer extends PackageViewServer {
     transcriptDir: string,
     transcriptId: string,
     searchId: string,
-    scope: { events?: string; messages?: string } | undefined
+    searchScope: { events?: string; messages?: string } | undefined,
+    pathScope: ViewPathScope
   ): Promise<string> {
+    await assertPathInViewScope(pathScope, transcriptDir);
     const params = new URLSearchParams();
-    if (scope?.messages) {
-      params.set("messages", scope.messages);
+    if (searchScope?.messages) {
+      params.set("messages", searchScope.messages);
     }
-    if (scope?.events) {
-      params.set("events", scope.events);
+    if (searchScope?.events) {
+      params.set("events", searchScope.events);
     }
     const query = params.toString();
     const path =
@@ -425,18 +506,31 @@ export class InspectViewServer extends PackageViewServer {
     // A result that isn't ready yet is a 404; return the JSON literal `null`
     // so the viewer reads it as "keep polling" rather than an error.
     return (
-      await this.api_json(path, "GET", undefined, (status) =>
-        status === 404 ? "null" : undefined
+      await this.api_json(
+        path,
+        "GET",
+        undefined,
+        (status) => (status === 404 ? "null" : undefined),
+        pathScope
       )
     ).data;
   }
 
-  public async logMessage(log_file: string, message?: string): Promise<void> {
+  public async logMessage(
+    log_file: string,
+    message: string | undefined,
+    scope: ViewPathScope
+  ): Promise<void> {
+    await assertPathInViewScope(scope, log_file);
     if (hasMinimumInspectVersion(kInspectLogMessageVersion)) {
       await this.api_json(
         `/api/log-message/${encodeURIComponent(log_file)}?message=${encodeURIComponent(
           message || ""
-        )}`
+        )}`,
+        "GET",
+        undefined,
+        undefined,
+        scope
       );
       return undefined;
     } else {

--- a/src/providers/lognotify.ts
+++ b/src/providers/lognotify.ts
@@ -36,7 +36,7 @@ export function activateLogNotify(
         return;
       }
 
-      if (viewManager.logFileWillVisiblyUpdate(e.log)) {
+      if (await viewManager.logFileWillVisiblyUpdate(e.log)) {
         return false;
       }
 

--- a/src/providers/logview/log-file-selector.ts
+++ b/src/providers/logview/log-file-selector.ts
@@ -2,7 +2,7 @@ import { Uri, window } from "vscode";
 
 import { resolveLogFile } from "./logview-link-provider";
 
-export async function selectFileUri(): Promise<Uri | undefined> {
+export async function selectFileUri(): Promise<Uri | string | undefined> {
   const uriOrPath = await window.showInputBox({
     title: "Select Log File",
     prompt: "Provide a path to a log file",
@@ -21,6 +21,9 @@ export async function selectFileUri(): Promise<Uri | undefined> {
     },
   });
   if (uriOrPath) {
+    if (/^https?:\/\//i.test(uriOrPath)) {
+      return uriOrPath;
+    }
     return await resolveLogFile(uriOrPath);
   } else {
     return undefined;

--- a/src/providers/logview/logview-editor.ts
+++ b/src/providers/logview/logview-editor.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { Uri } from "vscode";
 
 import { log } from "../../core/log";
-import { dirname, fileViewPathScope } from "../../core/uri";
+import { dirname, fileViewPathScope, viewPathUriString } from "../../core/uri";
 import { HostWebviewPanel } from "../../hooks";
 import { inspectViewPath } from "../../inspect/props";
 import { hasMinimumInspectVersion } from "../../inspect/version";
@@ -95,7 +95,7 @@ class InspectLogReadonlyEditor implements vscode.CustomReadonlyEditorProvider {
     const epoch = doc.epoch;
 
     const resourceUri = doc.resourceUri;
-    const resourceUriString = resourceUri.toString();
+    const resourceUriString = viewPathUriString(resourceUri);
 
     // check if we should use the log viewer (version check + size threshold)
     let useLogViewer = hasMinimumInspectVersion(kInspectEvalLogFormatVersion);

--- a/src/providers/logview/logview-editor.ts
+++ b/src/providers/logview/logview-editor.ts
@@ -2,7 +2,13 @@ import * as vscode from "vscode";
 import { Uri } from "vscode";
 
 import { log } from "../../core/log";
-import { dirname, fileViewPathScope, viewPathUriString } from "../../core/uri";
+import {
+  canonicalViewPathLocationFromUri,
+  dirname,
+  fileViewPathScope,
+  viewPathLocationFromUri,
+  viewPathUriString,
+} from "../../core/uri";
 import { HostWebviewPanel } from "../../hooks";
 import { inspectViewPath } from "../../inspect/props";
 import { hasMinimumInspectVersion } from "../../inspect/version";
@@ -16,30 +22,42 @@ export const kInspectLogViewType = "inspect-ai.log-editor";
 
 interface InspectLogDocument extends vscode.CustomDocument {
   resourceUri: Uri;
+  resourceLocation: string;
+  canonicalLocation: boolean;
   sample_id?: string;
   epoch?: string;
 }
 
 export function resolveLogDocumentLocation(uri: Uri): {
   resourceUri: Uri;
+  resourceLocation: string;
+  canonicalLocation: boolean;
   sample_id?: string;
   epoch?: string;
 } {
+  const canonicalLocation = canonicalViewPathLocationFromUri(uri);
+  const opaqueLocation = viewPathLocationFromUri(uri);
   const queryParams = new URLSearchParams(uri.query);
   const sampleIds = queryParams.getAll("sample_id");
   const epochs = queryParams.getAll("epoch");
   const isViewStateQuery =
+    !canonicalLocation &&
+    !opaqueLocation &&
     sampleIds.length === 1 &&
     epochs.length === 1 &&
     [...queryParams.keys()].every(
       (key) => key === "sample_id" || key === "epoch"
     );
 
+  const resourceUri = uri.with({
+    query: isViewStateQuery ? "" : uri.query,
+    fragment: "",
+  });
   return {
-    resourceUri: uri.with({
-      query: isViewStateQuery ? "" : uri.query,
-      fragment: "",
-    }),
+    resourceUri,
+    resourceLocation:
+      canonicalLocation ?? opaqueLocation ?? viewPathUriString(resourceUri),
+    canonicalLocation: canonicalLocation !== undefined,
     sample_id: isViewStateQuery ? sampleIds[0] : undefined,
     epoch: isViewStateQuery ? epochs[0] : undefined,
   };
@@ -95,15 +113,20 @@ class InspectLogReadonlyEditor implements vscode.CustomReadonlyEditorProvider {
     const epoch = doc.epoch;
 
     const resourceUri = doc.resourceUri;
-    const resourceUriString = viewPathUriString(resourceUri);
+    const resourceLocation = doc.resourceLocation;
+    const canonicalLocation = doc.canonicalLocation;
 
     // check if we should use the log viewer (version check + size threshold)
     let useLogViewer = hasMinimumInspectVersion(kInspectEvalLogFormatVersion);
     if (useLogViewer) {
       if (resourceUri.path.endsWith(".json")) {
         const fileSize = await this.server_.evalLogSize(
-          resourceUriString,
-          fileViewPathScope(resourceUri)
+          resourceLocation,
+          fileViewPathScope(
+            resourceUri,
+            canonicalLocation ? undefined : resourceLocation,
+            canonicalLocation ? resourceLocation : undefined
+          )
         );
         if (fileSize > 1024 * 1000 * 100) {
           log.info(
@@ -115,7 +138,11 @@ class InspectLogReadonlyEditor implements vscode.CustomReadonlyEditorProvider {
     }
 
     if (useLogViewer) {
-      const pathScope = fileViewPathScope(resourceUri);
+      const pathScope = fileViewPathScope(
+        resourceUri,
+        canonicalLocation ? undefined : resourceLocation,
+        canonicalLocation ? resourceLocation : undefined
+      );
       await pathScope.canonicalUri;
 
       // local resource roots
@@ -144,6 +171,8 @@ class InspectLogReadonlyEditor implements vscode.CustomReadonlyEditorProvider {
       // set html
       const logViewState: LogviewState = {
         log_file: resourceUri,
+        log_location: resourceLocation,
+        canonical_location: canonicalLocation,
         log_dir: dirname(resourceUri),
         sample:
           sample_id && epoch
@@ -159,7 +188,7 @@ class InspectLogReadonlyEditor implements vscode.CustomReadonlyEditorProvider {
       const viewColumn = webviewPanel.viewColumn;
       await vscode.commands.executeCommand(
         "vscode.openWith",
-        document.uri,
+        resourceUri,
         "default",
         viewColumn
       );

--- a/src/providers/logview/logview-editor.ts
+++ b/src/providers/logview/logview-editor.ts
@@ -14,6 +14,37 @@ import { LogviewState } from "./logview-state";
 
 export const kInspectLogViewType = "inspect-ai.log-editor";
 
+interface InspectLogDocument extends vscode.CustomDocument {
+  resourceUri: Uri;
+  sample_id?: string;
+  epoch?: string;
+}
+
+export function resolveLogDocumentLocation(uri: Uri): {
+  resourceUri: Uri;
+  sample_id?: string;
+  epoch?: string;
+} {
+  const queryParams = new URLSearchParams(uri.query);
+  const sampleIds = queryParams.getAll("sample_id");
+  const epochs = queryParams.getAll("epoch");
+  const isViewStateQuery =
+    sampleIds.length === 1 &&
+    epochs.length === 1 &&
+    [...queryParams.keys()].every(
+      (key) => key === "sample_id" || key === "epoch"
+    );
+
+  return {
+    resourceUri: uri.with({
+      query: isViewStateQuery ? "" : uri.query,
+      fragment: "",
+    }),
+    sample_id: isViewStateQuery ? sampleIds[0] : undefined,
+    epoch: isViewStateQuery ? epochs[0] : undefined,
+  };
+}
+
 class InspectLogReadonlyEditor implements vscode.CustomReadonlyEditorProvider {
   static register(
     context: vscode.ExtensionContext,
@@ -44,18 +75,14 @@ class InspectLogReadonlyEditor implements vscode.CustomReadonlyEditorProvider {
     _openContext: vscode.CustomDocumentOpenContext,
     _token: vscode.CancellationToken
   ): Promise<vscode.CustomDocument> {
-    // Parse any params from the Uri
-    const queryParams = new URLSearchParams(uri.query);
-    const sample_id = queryParams.get("sample_id");
-    const epoch = queryParams.get("epoch");
+    const location = resolveLogDocumentLocation(uri);
 
     // Return the document with additional info attached to payload
     return {
       uri: uri,
       dispose: () => {},
-      sample_id,
-      epoch,
-    } as vscode.CustomDocument & { sample_id?: string; epoch?: string };
+      ...location,
+    } satisfies InspectLogDocument;
   }
 
   async resolveCustomEditor(
@@ -63,23 +90,20 @@ class InspectLogReadonlyEditor implements vscode.CustomReadonlyEditorProvider {
     webviewPanel: vscode.WebviewPanel,
     _token: vscode.CancellationToken
   ): Promise<void> {
-    const doc = document as vscode.CustomDocument & {
-      sample_id?: string;
-      epoch?: string;
-    };
+    const doc = document as InspectLogDocument;
     const sample_id = doc.sample_id;
     const epoch = doc.epoch;
 
-    const docUriNoParams = document.uri.with({ query: "", fragment: "" });
-    const docUriStr = docUriNoParams.toString();
+    const resourceUri = doc.resourceUri;
+    const resourceUriString = resourceUri.toString();
 
     // check if we should use the log viewer (version check + size threshold)
     let useLogViewer = hasMinimumInspectVersion(kInspectEvalLogFormatVersion);
     if (useLogViewer) {
-      if (docUriStr.endsWith(".json")) {
+      if (resourceUri.path.endsWith(".json")) {
         const fileSize = await this.server_.evalLogSize(
-          docUriStr,
-          fileViewPathScope(docUriNoParams)
+          resourceUriString,
+          fileViewPathScope(resourceUri)
         );
         if (fileSize > 1024 * 1000 * 100) {
           log.info(
@@ -91,6 +115,9 @@ class InspectLogReadonlyEditor implements vscode.CustomReadonlyEditorProvider {
     }
 
     if (useLogViewer) {
+      const pathScope = fileViewPathScope(resourceUri);
+      await pathScope.canonicalUri;
+
       // local resource roots
       const localResourceRoots: Uri[] = [];
       const viewDir = inspectViewPath();
@@ -111,14 +138,13 @@ class InspectLogReadonlyEditor implements vscode.CustomReadonlyEditorProvider {
         webviewPanel as HostWebviewPanel,
         this.context_,
         this.server_,
-        "file",
-        docUriNoParams
+        pathScope
       );
 
       // set html
       const logViewState: LogviewState = {
-        log_file: docUriNoParams,
-        log_dir: dirname(docUriNoParams),
+        log_file: resourceUri,
+        log_dir: dirname(resourceUri),
         sample:
           sample_id && epoch
             ? {

--- a/src/providers/logview/logview-editor.ts
+++ b/src/providers/logview/logview-editor.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { Uri } from "vscode";
 
 import { log } from "../../core/log";
-import { dirname } from "../../core/uri";
+import { dirname, fileViewPathScope } from "../../core/uri";
 import { HostWebviewPanel } from "../../hooks";
 import { inspectViewPath } from "../../inspect/props";
 import { hasMinimumInspectVersion } from "../../inspect/version";
@@ -77,7 +77,10 @@ class InspectLogReadonlyEditor implements vscode.CustomReadonlyEditorProvider {
     let useLogViewer = hasMinimumInspectVersion(kInspectEvalLogFormatVersion);
     if (useLogViewer) {
       if (docUriStr.endsWith(".json")) {
-        const fileSize = await this.server_.evalLogSize(docUriStr);
+        const fileSize = await this.server_.evalLogSize(
+          docUriStr,
+          fileViewPathScope(docUriNoParams)
+        );
         if (fileSize > 1024 * 1000 * 100) {
           log.info(
             `JSON log file ${document.uri.path} is to large for Inspect View, opening in text editor.`

--- a/src/providers/logview/logview-link-provider.ts
+++ b/src/providers/logview/logview-link-provider.ts
@@ -120,7 +120,7 @@ export const logviewTerminalLinkProvider = (
       // Resolve the clicked link into a complete Uri to the file
       const logUri = await resolveLogFile(link.data);
       if (logUri) {
-        await commands.executeCommand("inspect.openLogViewer", logUri);
+        await commands.executeCommand("inspect.openLogViewer", link.data);
       } else {
         // Since we couldn't resolve the log file, just let the user know
         const close: MessageItem = { title: "Close" };

--- a/src/providers/logview/logview-panel.ts
+++ b/src/providers/logview/logview-panel.ts
@@ -25,8 +25,9 @@ import { log } from "../../core/log";
 import { HttpProxyRpcRequest } from "../../core/package/view-server";
 import {
   pathIsInViewScope,
-  resolveViewPathCandidate,
+  resolvePathInViewScope,
   ViewPathScope,
+  viewPathUriString,
 } from "../../core/uri";
 import {
   getWebviewPanelHtml,
@@ -170,9 +171,7 @@ export class LogviewPanel extends Disposable {
   }
 
   public async resolve(location: string | Uri): Promise<Uri | null> {
-    return (await this.allows(location))
-      ? resolveViewPathCandidate(this.scope_, location)
-      : null;
+    return await resolvePathInViewScope(this.scope_, location);
   }
 
   public async getHtml(state: LogviewState): Promise<string> {
@@ -197,7 +196,7 @@ export class LogviewPanel extends Disposable {
     // message being sent before the view itself is configured to receive messages)
     const stateMsg = {
       type: "updateState",
-      url: state.log_file?.toString(),
+      url: state.log_file ? viewPathUriString(state.log_file) : undefined,
       sample_id: state.sample?.id,
       sample_epoch: state.sample?.epoch,
     };

--- a/src/providers/logview/logview-panel.ts
+++ b/src/providers/logview/logview-panel.ts
@@ -27,7 +27,7 @@ import {
   pathIsInViewScope,
   resolvePathInViewScope,
   ViewPathScope,
-  viewPathUriString,
+  viewPathScopeLocation,
 } from "../../core/uri";
 import {
   getWebviewPanelHtml,
@@ -77,7 +77,7 @@ export class LogviewPanel extends Disposable {
       [kMethodEvalLogs]: async () =>
         type === "dir"
           ? server_.evalLogs(uri, this.scope_)
-          : server_.evalLogsSolo(uri),
+          : server_.evalLogsSolo(uri, this.scope_),
       [kMethodEvalLog]: (params: unknown[]) =>
         server_.evalLog(
           params[0] as string,
@@ -196,7 +196,9 @@ export class LogviewPanel extends Disposable {
     // message being sent before the view itself is configured to receive messages)
     const stateMsg = {
       type: "updateState",
-      url: state.log_file ? viewPathUriString(state.log_file) : undefined,
+      url: state.log_file
+        ? await viewPathScopeLocation(this.scope_)
+        : undefined,
       sample_id: state.sample?.id,
       sample_epoch: state.sample?.epoch,
     };

--- a/src/providers/logview/logview-panel.ts
+++ b/src/providers/logview/logview-panel.ts
@@ -22,6 +22,11 @@ import {
 } from "../../core/jsonrpc";
 import { log } from "../../core/log";
 import {
+  pathIsInViewScope,
+  resolveViewPathCandidate,
+  ViewPathScope,
+} from "../../core/uri";
+import {
   getWebviewPanelHtml,
   handleWebviewPanelOpenMessages,
 } from "../../core/webview";
@@ -40,48 +45,61 @@ export class LogviewPanel extends Disposable {
     uri: Uri
   ) {
     super();
+    this.scope_ = {
+      kind: type === "dir" ? "directory" : "file",
+      uri,
+    };
 
     // serve eval log api to webview
     this._rpcDisconnect = webviewPanelJsonRpcServer(panel_, {
-      [kMethodEvalLogDir]: async () => {
+      [kMethodEvalLogDir]: () => {
         if (type === "dir") {
-          return JSON.stringify({ log_dir: uri.toString() });
+          return Promise.resolve(JSON.stringify({ log_dir: uri.toString() }));
         }
-        const result = await server_.evalLogDir();
-        return result;
+        return Promise.resolve(JSON.stringify({ log_dir: "" }));
       },
       [kMethodEvalLogFiles]: async (params: unknown[]) =>
         type === "dir"
           ? server_.evalLogFiles(
               uri.toString(),
               params[0] as number,
-              params[1] as number
+              params[1] as number,
+              this.scope_
             )
           : Promise.resolve(undefined),
       [kMethodEvalLogs]: async () =>
-        type === "dir" ? server_.evalLogs(uri) : server_.evalLogsSolo(uri),
+        type === "dir"
+          ? server_.evalLogs(uri, this.scope_)
+          : server_.evalLogsSolo(uri),
       [kMethodEvalLog]: (params: unknown[]) =>
-        server_.evalLog(params[0] as string, params[1] as number | boolean),
+        server_.evalLog(
+          params[0] as string,
+          params[1] as number | boolean,
+          this.scope_
+        ),
       [kMethodEvalLogSize]: (params: unknown[]) =>
-        server_.evalLogSize(params[0] as string),
+        server_.evalLogSize(params[0] as string, this.scope_),
       [kMethodEvalLogBytes]: (params: unknown[]) =>
         server_.evalLogBytes(
           params[0] as string,
           params[1] as number,
-          params[2] as number
+          params[2] as number,
+          this.scope_
         ),
       [kMethodEvalLogHeaders]: (params: unknown[]) =>
-        server_.evalLogHeaders(params[0] as string[]),
+        server_.evalLogHeaders(params[0] as string[], this.scope_),
       [kMethodPendingSamples]: (params: unknown[]) =>
         server_.evalLogPendingSamples(
           params[0] as string,
-          params[1] as string | undefined
+          params[1] as string | undefined,
+          this.scope_
         ),
       [kMethodSampleData]: (params: unknown[]) =>
         server_.evalLogSampleData(
           params[0] as string,
           params[1] as string | number,
           params[2] as number,
+          this.scope_,
           params[3] as number | undefined,
           params[4] as number | undefined
         ),
@@ -89,26 +107,33 @@ export class LogviewPanel extends Disposable {
         const log_file = params[0] as string;
         const message = params[1] as string | undefined;
         log.info(`[CLIENT LOG] (${log_file}): ${message}`);
-        await server_.logMessage(log_file, message);
+        await server_.logMessage(log_file, message, this.scope_);
       },
       [kMethodEditLog]: (params: unknown[]) =>
         server_.editLog(
           params[0] as string,
           params[1],
-          params[2] as string | undefined
+          params[2] as string | undefined,
+          this.scope_
         ),
       [kMethodGetUserInfo]: () => server_.getUserInfo(),
       [kMethodAppConfig]: () => server_.getAppConfig(),
       [kMethodListSearches]: (params: unknown[]) =>
         server_.listSearches(params[0] as string, params[1] as number),
       [kMethodPostSearch]: (params: unknown[]) =>
-        server_.postSearch(params[0] as string, params[1] as string, params[2]),
+        server_.postSearch(
+          params[0] as string,
+          params[1] as string,
+          params[2],
+          this.scope_
+        ),
       [kMethodGetSearchResult]: (params: unknown[]) =>
         server_.getSearchResult(
           params[0] as string,
           params[1] as string,
           params[2] as string,
-          params[3] as { events?: string; messages?: string } | undefined
+          params[3] as { events?: string; messages?: string } | undefined,
+          this.scope_
         ),
     });
 
@@ -119,6 +144,20 @@ export class LogviewPanel extends Disposable {
   public override dispose() {
     this._rpcDisconnect();
     this._pmUnsubcribe.dispose();
+  }
+
+  public scope(): ViewPathScope {
+    return this.scope_;
+  }
+
+  public allows(location: string | Uri): Promise<boolean> {
+    return pathIsInViewScope(this.scope_, location);
+  }
+
+  public async resolve(location: string | Uri): Promise<Uri | null> {
+    return (await this.allows(location))
+      ? resolveViewPathCandidate(this.scope_, location)
+      : null;
   }
 
   public async getHtml(state: LogviewState): Promise<string> {
@@ -174,4 +213,5 @@ export class LogviewPanel extends Disposable {
 
   private _rpcDisconnect: VoidFunction;
   private _pmUnsubcribe: vscode.Disposable;
+  private readonly scope_: ViewPathScope;
 }

--- a/src/providers/logview/logview-panel.ts
+++ b/src/providers/logview/logview-panel.ts
@@ -41,14 +41,11 @@ export class LogviewPanel extends Disposable {
     private panel_: HostWebviewPanel,
     private context_: ExtensionContext,
     private server_: InspectViewServer,
-    type: "file" | "dir",
-    uri: Uri
+    private readonly scope_: ViewPathScope
   ) {
     super();
-    this.scope_ = {
-      kind: type === "dir" ? "directory" : "file",
-      uri,
-    };
+    const type = scope_.kind === "directory" ? "dir" : "file";
+    const uri = scope_.uri;
 
     // serve eval log api to webview
     this._rpcDisconnect = webviewPanelJsonRpcServer(panel_, {
@@ -161,6 +158,8 @@ export class LogviewPanel extends Disposable {
   }
 
   public async getHtml(state: LogviewState): Promise<string> {
+    await this.scope_.canonicalUri;
+
     // Try to resolve the dist path from the server (handles LFS resolution),
     // falling back to the local scoutViewPath() if the endpoint isn't available.
     const distDir = await this.server_.getDistPath();
@@ -213,5 +212,4 @@ export class LogviewPanel extends Disposable {
 
   private _rpcDisconnect: VoidFunction;
   private _pmUnsubcribe: vscode.Disposable;
-  private readonly scope_: ViewPathScope;
 }

--- a/src/providers/logview/logview-state.ts
+++ b/src/providers/logview/logview-state.ts
@@ -9,6 +9,8 @@ import {
 
 export interface LogviewState {
   log_file?: Uri;
+  log_location?: string;
+  canonical_location?: boolean;
   log_dir: Uri;
   scope_kind?: "directory" | "file";
   path_scope?: ViewPathScope;
@@ -25,7 +27,11 @@ export function logviewPathScope(state: LogviewState): ViewPathScope {
   }
   const kind = state.scope_kind ?? (state.log_file ? "file" : "directory");
   return kind === "file"
-    ? fileViewPathScope(state.log_file ?? state.log_dir)
+    ? fileViewPathScope(
+        state.log_file ?? state.log_dir,
+        state.canonical_location ? undefined : state.log_location,
+        state.canonical_location ? state.log_location : undefined
+      )
     : directoryViewPathScope(state.log_dir);
 }
 

--- a/src/providers/logview/logview-state.ts
+++ b/src/providers/logview/logview-state.ts
@@ -1,12 +1,37 @@
 import { Uri } from "vscode";
 
+import {
+  directoryViewPathScope,
+  fileViewPathScope,
+  pathIsInViewScope,
+  ViewPathScope,
+} from "../../core/uri";
+
 export interface LogviewState {
   log_file?: Uri;
   log_dir: Uri;
   scope_kind?: "directory" | "file";
+  path_scope?: ViewPathScope;
   sample?: {
     id: string;
     epoch: string;
   };
   background_refresh?: boolean;
+}
+
+export function logviewPathScope(state: LogviewState): ViewPathScope {
+  if (state.path_scope) {
+    return state.path_scope;
+  }
+  const kind = state.scope_kind ?? (state.log_file ? "file" : "directory");
+  return kind === "file"
+    ? fileViewPathScope(state.log_file ?? state.log_dir)
+    : directoryViewPathScope(state.log_dir);
+}
+
+export async function logFileIsInLogviewScope(
+  scope: ViewPathScope,
+  logFile: Uri
+): Promise<boolean> {
+  return await pathIsInViewScope(scope, logFile);
 }

--- a/src/providers/logview/logview-state.ts
+++ b/src/providers/logview/logview-state.ts
@@ -3,6 +3,7 @@ import { Uri } from "vscode";
 export interface LogviewState {
   log_file?: Uri;
   log_dir: Uri;
+  scope_kind?: "directory" | "file";
   sample?: {
     id: string;
     epoch: string;

--- a/src/providers/logview/logview-view.ts
+++ b/src/providers/logview/logview-view.ts
@@ -10,7 +10,7 @@ import {
   PackageManager,
 } from "../../core/package/manager";
 import { OutputWatcher } from "../../core/package/output-watcher";
-import { dirname, getRelativeUri } from "../../core/uri";
+import { dirname, ViewPathScope, viewPathScopesEqual } from "../../core/uri";
 import { HostWebviewPanel } from "../../hooks";
 import { inspectViewPath } from "../../inspect/props";
 import { selectLogDirectory } from "../activity-bar/log-listing/log-directory-selector";
@@ -18,7 +18,11 @@ import { InspectViewServer } from "../inspect/inspect-view-server";
 import { WorkspaceEnvManager } from "../workspace/workspace-env-provider";
 
 import { LogviewPanel } from "./logview-panel";
-import { LogviewState } from "./logview-state";
+import {
+  logFileIsInLogviewScope,
+  logviewPathScope,
+  LogviewState,
+} from "./logview-state";
 
 const kLogViewId = "inspect.logview";
 
@@ -31,10 +35,9 @@ export class InspectViewManager {
   ) {
     this.context_.subscriptions.push(
       outputWatcher.onInspectLogCreated(async (e) => {
-        // if this log is contained in the directory currently being viewed
-        // then do a background refresh on it
+        // Refresh only when the new log is allowed by the current view scope.
         if (this.webViewManager_.hasWebview()) {
-          await this.webViewManager_.showLogFileIfWithinLogDir(e.log);
+          await this.webViewManager_.showLogFileIfInViewScope(e.log);
         }
       })
     );
@@ -59,10 +62,10 @@ export class InspectViewManager {
     await this.webViewManager_.showLogFile(uri, activation);
   }
 
-  public logFileWillVisiblyUpdate(uri: Uri): boolean {
+  public async logFileWillVisiblyUpdate(uri: Uri): Promise<boolean> {
     return (
       this.webViewManager_.isVisible() &&
-      this.webViewManager_.logFileIsWithinLogDir(uri)
+      (await this.webViewManager_.logFileIsInViewScope(uri))
     );
   }
 
@@ -105,7 +108,6 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
       InspectViewWebview
     );
   }
-  private activeLogDir_: Uri | null = null;
 
   public async showLogFile(uri: Uri, activation?: "open" | "activate") {
     // Get the directory name using posix path methods
@@ -117,25 +119,29 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
     );
   }
 
-  public logFileIsWithinLogDir(log_file: Uri) {
+  public async logFileIsInViewScope(log_file: Uri): Promise<boolean> {
     const state = this.getWorkspaceState();
+    const scope =
+      this.activeView_?.scope() ??
+      (state ? logviewPathScope(state) : undefined);
     return (
-      state?.log_dir !== undefined &&
-      getRelativeUri(state?.log_dir, log_file) !== null
+      scope !== undefined && (await logFileIsInLogviewScope(scope, log_file))
     );
   }
 
-  public async showLogFileIfWithinLogDir(log_file: Uri) {
+  public async showLogFileIfInViewScope(log_file: Uri) {
     const state = this.getWorkspaceState();
-    if (state?.log_dir) {
-      if (getRelativeUri(state?.log_dir, log_file) !== null) {
-        await this.displayLogFile({
-          log_file: log_file,
-          log_dir: state?.log_dir,
-          scope_kind: state.scope_kind ?? "directory",
-          background_refresh: true,
-        });
+    if (state) {
+      const scope = this.activeView_?.scope() ?? logviewPathScope(state);
+      if (!(await logFileIsInLogviewScope(scope, log_file))) {
+        return;
       }
+      await this.displayLogFile({
+        log_file: log_file,
+        log_dir: state.log_dir,
+        scope_kind: scope.kind,
+        background_refresh: true,
+      });
     }
   }
 
@@ -162,7 +168,7 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
           // or to check whether the view is focused and call us back to
           // display a log file
           await this.activeView_?.backgroundUpdate(
-            state.log_file.path,
+            state.log_file.toString(),
             state.log_dir.toString()
           );
         }
@@ -184,19 +190,19 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
     state: LogviewState,
     activation?: "open" | "activate"
   ) {
-    // Determine whether we are showing a log viewer for this directory
-    // If we aren't close the log viewer so a fresh one can be opened.
-    if (
-      this.activeLogDir_ !== null &&
-      state.log_dir.toString() !== this.activeLogDir_.toString()
-    ) {
-      // Close it
+    const activeScope = this.activeView_?.scope();
+    const requestedScope = logviewPathScope(state);
+    const scope =
+      activeScope && viewPathScopesEqual(activeScope, requestedScope)
+        ? activeScope
+        : requestedScope;
+    await scope.canonicalUri;
+    if (activeScope && activeScope !== scope) {
       this.activeView_?.dispose();
       this.activeView_ = undefined;
     }
 
-    // Note the log directory that we are showing
-    this.activeLogDir_ = state.log_dir || null;
+    state = { ...state, path_scope: scope };
 
     // Update the view state
     this.updateViewState(state);
@@ -209,7 +215,6 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
     // If the view is closed, clear the state
     this.setOnClose(() => {
       this.lastState_ = undefined;
-      this.activeLogDir_ = null;
     });
 
     // Actually reveal or show the webview
@@ -218,7 +223,7 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
         this.revealWebview(activation !== "activate");
       } else if (state.log_file) {
         await this.activeView_?.backgroundUpdate(
-          state.log_file.path,
+          state.log_file.toString(),
           state.log_dir.toString()
         );
       }
@@ -311,15 +316,8 @@ class InspectViewWebview extends InspectWebview<LogviewState> {
   ) {
     super(context, webviewPanel);
 
-    const scopeKind =
-      state.scope_kind ?? (state.log_file ? "file" : "directory");
-    this.logviewPanel_ = new LogviewPanel(
-      webviewPanel,
-      context,
-      server,
-      scopeKind === "file" ? "file" : "dir",
-      scopeKind === "file" && state.log_file ? state.log_file : state.log_dir
-    );
+    const scope = logviewPathScope(state);
+    this.logviewPanel_ = new LogviewPanel(webviewPanel, context, server, scope);
     this._register(this.logviewPanel_);
 
     this._register(
@@ -359,6 +357,10 @@ class InspectViewWebview extends InspectWebview<LogviewState> {
     }
   }
   _manager: InspectViewWebviewManager | undefined;
+
+  public scope(): ViewPathScope {
+    return this.logviewPanel_.scope();
+  }
 
   public async update(state: LogviewState) {
     await this._webviewPanel.webview.postMessage({

--- a/src/providers/logview/logview-view.ts
+++ b/src/providers/logview/logview-view.ts
@@ -13,6 +13,7 @@ import { OutputWatcher } from "../../core/package/output-watcher";
 import {
   dirname,
   ViewPathScope,
+  viewPathScopeLocation,
   viewPathScopesEqual,
   viewPathUriString,
 } from "../../core/uri";
@@ -63,8 +64,18 @@ export class InspectViewManager {
     }
   }
 
-  public async showLogFile(uri: Uri, activation?: "open" | "activate") {
-    await this.webViewManager_.showLogFile(uri, activation);
+  public async showLogFile(
+    uri: Uri,
+    activation?: "open" | "activate",
+    location?: string,
+    canonical: boolean = false
+  ) {
+    await this.webViewManager_.showLogFile(
+      uri,
+      activation,
+      location,
+      canonical
+    );
   }
 
   public async logFileWillVisiblyUpdate(uri: Uri): Promise<boolean> {
@@ -114,12 +125,23 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
     );
   }
 
-  public async showLogFile(uri: Uri, activation?: "open" | "activate") {
+  public async showLogFile(
+    uri: Uri,
+    activation?: "open" | "activate",
+    location?: string,
+    canonical: boolean = false
+  ) {
     // Get the directory name using posix path methods
     const log_dir = dirname(uri);
 
     await this.showLogview(
-      { log_file: uri, log_dir, scope_kind: "file" },
+      {
+        log_file: uri,
+        log_location: location,
+        canonical_location: canonical,
+        log_dir,
+        scope_kind: "file",
+      },
       activation
     );
   }
@@ -143,6 +165,10 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
       }
       await this.displayLogFile({
         log_file: log_file,
+        log_location: scope.canonical
+          ? await viewPathScopeLocation(scope)
+          : scope.opaqueLocation,
+        canonical_location: scope.canonical,
         log_dir: state.log_dir,
         scope_kind: scope.kind,
         background_refresh: true,
@@ -173,7 +199,7 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
           // or to check whether the view is focused and call us back to
           // display a log file
           await this.activeView_?.backgroundUpdate(
-            viewPathUriString(state.log_file),
+            state.log_location ?? viewPathUriString(state.log_file),
             state.log_dir.toString()
           );
         }
@@ -228,7 +254,7 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
         this.revealWebview(activation !== "activate");
       } else if (state.log_file) {
         await this.activeView_?.backgroundUpdate(
-          viewPathUriString(state.log_file),
+          state.log_location ?? viewPathUriString(state.log_file),
           state.log_dir.toString()
         );
       }
@@ -266,6 +292,8 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
       return {
         log_dir: Uri.parse(data["log_dir"] ?? ""),
         log_file: data["log_file"] ? Uri.parse(data["log_file"]) : undefined,
+        log_location: data["log_location"] || undefined,
+        canonical_location: data["canonical_location"] === "true",
         background_refresh: !!data["background_refresh"],
         scope_kind:
           data["scope_kind"] === "file" ||
@@ -282,6 +310,8 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
     void this.context_.workspaceState.update(this.kInspectViewState, {
       log_dir: state.log_dir.toString(),
       log_file: state.log_file ? viewPathUriString(state.log_file) : undefined,
+      log_location: state.log_location,
+      canonical_location: state.canonical_location ? "true" : undefined,
       background_refresh: state.background_refresh,
       scope_kind: state.scope_kind,
     });
@@ -305,7 +335,11 @@ const logStateEquals = (a: LogviewState, b: LogviewState) => {
   } else if (a.log_file && !b.log_file) {
     return false;
   } else if (a.log_file && b.log_file) {
-    return viewPathUriString(a.log_file) === viewPathUriString(b.log_file);
+    return (
+      !!a.canonical_location === !!b.canonical_location &&
+      (a.log_location ?? viewPathUriString(a.log_file)) ===
+        (b.log_location ?? viewPathUriString(b.log_file))
+    );
   }
   return true;
 };
@@ -336,6 +370,10 @@ class InspectViewWebview extends InspectWebview<LogviewState> {
                   const scope = this.logviewPanel_.scope();
                   const state: LogviewState = {
                     log_file: logFile,
+                    log_location: scope.canonical
+                      ? await viewPathScopeLocation(scope)
+                      : scope.opaqueLocation,
+                    canonical_location: scope.canonical,
                     log_dir:
                       scope.kind === "directory" ? scope.uri : dirname(logFile),
                     scope_kind: scope.kind,
@@ -370,7 +408,9 @@ class InspectViewWebview extends InspectWebview<LogviewState> {
   public async update(state: LogviewState) {
     await this._webviewPanel.webview.postMessage({
       type: "updateState",
-      url: state.log_file ? viewPathUriString(state.log_file) : undefined,
+      url: state.log_file
+        ? (state.log_location ?? viewPathUriString(state.log_file))
+        : undefined,
     });
   }
 

--- a/src/providers/logview/logview-view.ts
+++ b/src/providers/logview/logview-view.ts
@@ -10,7 +10,12 @@ import {
   PackageManager,
 } from "../../core/package/manager";
 import { OutputWatcher } from "../../core/package/output-watcher";
-import { dirname, ViewPathScope, viewPathScopesEqual } from "../../core/uri";
+import {
+  dirname,
+  ViewPathScope,
+  viewPathScopesEqual,
+  viewPathUriString,
+} from "../../core/uri";
 import { HostWebviewPanel } from "../../hooks";
 import { inspectViewPath } from "../../inspect/props";
 import { selectLogDirectory } from "../activity-bar/log-listing/log-directory-selector";
@@ -168,7 +173,7 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
           // or to check whether the view is focused and call us back to
           // display a log file
           await this.activeView_?.backgroundUpdate(
-            state.log_file.toString(),
+            viewPathUriString(state.log_file),
             state.log_dir.toString()
           );
         }
@@ -223,7 +228,7 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
         this.revealWebview(activation !== "activate");
       } else if (state.log_file) {
         await this.activeView_?.backgroundUpdate(
-          state.log_file.toString(),
+          viewPathUriString(state.log_file),
           state.log_dir.toString()
         );
       }
@@ -276,7 +281,7 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
   protected setWorkspaceState(state: LogviewState) {
     void this.context_.workspaceState.update(this.kInspectViewState, {
       log_dir: state.log_dir.toString(),
-      log_file: state.log_file?.toString(),
+      log_file: state.log_file ? viewPathUriString(state.log_file) : undefined,
       background_refresh: state.background_refresh,
       scope_kind: state.scope_kind,
     });
@@ -300,7 +305,7 @@ const logStateEquals = (a: LogviewState, b: LogviewState) => {
   } else if (a.log_file && !b.log_file) {
     return false;
   } else if (a.log_file && b.log_file) {
-    return a.log_file.toString() === b.log_file.toString();
+    return viewPathUriString(a.log_file) === viewPathUriString(b.log_file);
   }
   return true;
 };
@@ -365,7 +370,7 @@ class InspectViewWebview extends InspectWebview<LogviewState> {
   public async update(state: LogviewState) {
     await this._webviewPanel.webview.postMessage({
       type: "updateState",
-      url: state.log_file?.toString(),
+      url: state.log_file ? viewPathUriString(state.log_file) : undefined,
     });
   }
 

--- a/src/providers/logview/logview-view.ts
+++ b/src/providers/logview/logview-view.ts
@@ -48,7 +48,10 @@ export class InspectViewManager {
     }
     if (log_dir) {
       // Show the log view for the log dir (or the workspace)
-      await this.webViewManager_.showLogview({ log_dir }, "activate");
+      await this.webViewManager_.showLogview(
+        { log_dir, scope_kind: "directory" },
+        "activate"
+      );
     }
   }
 
@@ -108,7 +111,10 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
     // Get the directory name using posix path methods
     const log_dir = dirname(uri);
 
-    await this.showLogview({ log_file: uri, log_dir }, activation);
+    await this.showLogview(
+      { log_file: uri, log_dir, scope_kind: "file" },
+      activation
+    );
   }
 
   public logFileIsWithinLogDir(log_file: Uri) {
@@ -126,6 +132,7 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
         await this.displayLogFile({
           log_file: log_file,
           log_dir: state?.log_dir,
+          scope_kind: state.scope_kind ?? "directory",
           background_refresh: true,
         });
       }
@@ -250,6 +257,11 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
         log_dir: Uri.parse(data["log_dir"] ?? ""),
         log_file: data["log_file"] ? Uri.parse(data["log_file"]) : undefined,
         background_refresh: !!data["background_refresh"],
+        scope_kind:
+          data["scope_kind"] === "file" ||
+          (!data["scope_kind"] && data["log_file"])
+            ? "file"
+            : "directory",
       };
     } else {
       return this.lastState_;
@@ -261,6 +273,7 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
       log_dir: state.log_dir.toString(),
       log_file: state.log_file?.toString(),
       background_refresh: state.background_refresh,
+      scope_kind: state.scope_kind,
     });
   }
 
@@ -270,6 +283,9 @@ export class InspectViewWebviewManager extends InspectWebviewManager<
 }
 
 const logStateEquals = (a: LogviewState, b: LogviewState) => {
+  if ((a.scope_kind ?? "directory") !== (b.scope_kind ?? "directory")) {
+    return false;
+  }
   if (a.log_dir.toString() !== b.log_dir.toString()) {
     return false;
   }
@@ -295,12 +311,14 @@ class InspectViewWebview extends InspectWebview<LogviewState> {
   ) {
     super(context, webviewPanel);
 
+    const scopeKind =
+      state.scope_kind ?? (state.log_file ? "file" : "directory");
     this.logviewPanel_ = new LogviewPanel(
       webviewPanel,
       context,
       server,
-      "dir",
-      state.log_dir
+      scopeKind === "file" ? "file" : "dir",
+      scopeKind === "file" && state.log_file ? state.log_file : state.log_dir
     );
     this._register(this.logviewPanel_);
 
@@ -310,15 +328,19 @@ class InspectViewWebview extends InspectWebview<LogviewState> {
           switch (e.type) {
             case "displayLogFile":
               {
-                if (e.log_dir && this._manager) {
+                const logFile = await this.logviewPanel_.resolve(e.url);
+                if (this._manager && logFile) {
+                  const scope = this.logviewPanel_.scope();
                   const state: LogviewState = {
-                    log_file: Uri.parse(e.url),
-                    log_dir: Uri.parse(e.log_dir as string),
+                    log_file: logFile,
+                    log_dir:
+                      scope.kind === "directory" ? scope.uri : dirname(logFile),
+                    scope_kind: scope.kind,
                   };
                   await this._manager.displayLogFile(state, "open");
                 } else {
                   await showError(
-                    "Unable to display log file because of a missing log_dir or manager. This is an unexpected error, please report it."
+                    "Unable to display a log file outside the selected viewer scope."
                   );
                 }
               }

--- a/src/providers/openlog.ts
+++ b/src/providers/openlog.ts
@@ -1,5 +1,12 @@
 import { commands, ExtensionContext, Uri } from "vscode";
 
+import {
+  isOpaqueHttpViewLocation,
+  viewPathLocationFromUri,
+  viewPathUriString,
+  withCanonicalViewPathLocation,
+  withViewPathLocation,
+} from "../core/uri";
 import { withEditorAssociation } from "../core/vscode/association";
 import { hasMinimumInspectVersion } from "../inspect/version";
 
@@ -14,12 +21,25 @@ export function activateOpenLog(
   context.subscriptions.push(
     commands.registerCommand(
       "inspect.openLogViewer",
-      async (uri: Uri | string) => {
-        uri = typeof uri === "string" ? Uri.parse(uri) : uri;
+      async (uriOrLocation: Uri | string, canonicalLocation?: string) => {
+        const location =
+          typeof uriOrLocation === "string"
+            ? uriOrLocation
+            : (viewPathLocationFromUri(uriOrLocation) ??
+              viewPathUriString(uriOrLocation));
+        const uri =
+          typeof uriOrLocation === "string"
+            ? Uri.parse(uriOrLocation)
+            : uriOrLocation.with({ fragment: "" });
+        const editorUri = canonicalLocation
+          ? withCanonicalViewPathLocation(uri, canonicalLocation)
+          : withViewPathLocation(uri, location);
 
         // function to open using defualt editor in preview mode
         const openLogViewer = async () => {
-          await commands.executeCommand("vscode.open", uri, { preview: true });
+          await commands.executeCommand("vscode.open", editorUri, {
+            preview: true,
+          });
         };
 
         if (hasMinimumInspectVersion(kInspectEvalLogFormatVersion)) {
@@ -41,7 +61,13 @@ export function activateOpenLog(
           // notify the logs pane that we are doing this so that it can take a reveal action
           await commands.executeCommand("inspect.logListingReveal", uri);
         } else {
-          await viewManager.showLogFile(uri, "activate");
+          await viewManager.showLogFile(
+            uri,
+            "activate",
+            canonicalLocation ??
+              (isOpaqueHttpViewLocation(location) ? location : undefined),
+            canonicalLocation !== undefined
+          );
         }
       }
     )

--- a/src/providers/protocol-handler.ts
+++ b/src/providers/protocol-handler.ts
@@ -68,7 +68,7 @@ export class InspectProtocolHandler implements UriHandler {
           }
 
           // Execute the open command
-          await commands.executeCommand("inspect.openLogViewer", logUri);
+          await commands.executeCommand("inspect.openLogViewer", logFile);
         }
       }
     }

--- a/src/test/suite/inspect-view-server.test.ts
+++ b/src/test/suite/inspect-view-server.test.ts
@@ -2,6 +2,12 @@ import * as assert from "assert";
 
 import { Uri } from "vscode";
 
+import {
+  addViewScopeHeaders,
+  kViewScopeHeader,
+  kViewScopeKindHeader,
+} from "../../core/package/view-server";
+import { directoryViewPathScope } from "../../core/uri";
 import { InspectViewServer } from "../../providers/inspect/inspect-view-server";
 
 suite("InspectViewServer Test Suite", () => {
@@ -389,6 +395,17 @@ suite("InspectViewServer Test Suite", () => {
       const protocol = "http";
       assert.strictEqual(protocol, "http");
     });
+
+    test("scope headers carry the host-selected directory capability", () => {
+      const headers = new Headers();
+      addViewScopeHeaders(
+        headers,
+        directoryViewPathScope(Uri.parse("s3://bucket/logs"))
+      );
+
+      assert.strictEqual(headers.get(kViewScopeKindHeader), "directory");
+      assert.strictEqual(headers.get(kViewScopeHeader), "s3://bucket/logs");
+    });
   });
 
   suite("URI Encoding Edge Cases", () => {
@@ -473,6 +490,33 @@ suite("InspectViewServer Test Suite", () => {
   });
 
   suite("Integration Concepts", () => {
+    test("rejects an out-of-scope file before contacting the server", async () => {
+      const server = Object.create(
+        InspectViewServer.prototype
+      ) as InspectViewServer;
+      await assert.rejects(
+        server.evalLog(
+          "s3://other/logs/run.eval",
+          false,
+          directoryViewPathScope(Uri.parse("s3://bucket/logs"))
+        ),
+        /outside the selected directory scope/
+      );
+    });
+
+    test("rejects a batch when any file is outside scope", async () => {
+      const server = Object.create(
+        InspectViewServer.prototype
+      ) as InspectViewServer;
+      await assert.rejects(
+        server.evalLogHeaders(
+          ["s3://bucket/logs/run.eval", "s3://other/logs/private.eval"],
+          directoryViewPathScope(Uri.parse("s3://bucket/logs"))
+        ),
+        /outside the selected directory scope/
+      );
+    });
+
     test("should call ensureRunning before API requests", async () => {
       let ensureRunningCalled = false;
 

--- a/src/test/suite/inspect-view-server.test.ts
+++ b/src/test/suite/inspect-view-server.test.ts
@@ -396,9 +396,9 @@ suite("InspectViewServer Test Suite", () => {
       assert.strictEqual(protocol, "http");
     });
 
-    test("scope headers carry the host-selected directory capability", () => {
+    test("scope headers carry the host-selected directory capability", async () => {
       const headers = new Headers();
-      addViewScopeHeaders(
+      await addViewScopeHeaders(
         headers,
         directoryViewPathScope(Uri.parse("s3://bucket/logs"))
       );

--- a/src/test/suite/inspect-view-server.test.ts
+++ b/src/test/suite/inspect-view-server.test.ts
@@ -414,22 +414,16 @@ suite("InspectViewServer Test Suite", () => {
 
     test("scope headers preserve canonical signed query parameters", async () => {
       const headers = new Headers();
+      const location =
+        "https://example.test/run.eval?" +
+        "token=a%26b&credential=team%2Fmember";
       await addViewScopeHeaders(
         headers,
-        fileViewPathScope(
-          Uri.parse(
-            "https://example.test/run.eval?" +
-              "credential=team%2Fmember&label=hello%20world"
-          )
-        )
+        fileViewPathScope(Uri.parse(location), location)
       );
 
       assert.strictEqual(headers.get(kViewScopeKindHeader), "file");
-      assert.strictEqual(
-        headers.get(kViewScopeHeader),
-        "https://example.test/run.eval?" +
-          "credential=team%2Fmember&label=hello%20world"
-      );
+      assert.strictEqual(headers.get(kViewScopeHeader), location);
     });
   });
 

--- a/src/test/suite/inspect-view-server.test.ts
+++ b/src/test/suite/inspect-view-server.test.ts
@@ -8,7 +8,11 @@ import {
   kViewScopeHeader,
   kViewScopeKindHeader,
 } from "../../core/package/view-server";
-import { directoryViewPathScope } from "../../core/uri";
+import {
+  directoryViewPathScope,
+  fileViewPathScope,
+  viewPathUriString,
+} from "../../core/uri";
 import { InspectViewServer } from "../../providers/inspect/inspect-view-server";
 
 suite("InspectViewServer Test Suite", () => {
@@ -304,19 +308,19 @@ suite("InspectViewServer Test Suite", () => {
       const logFile = Uri.file("/test/log.json");
       const result = {
         log_dir: "",
-        files: [{ name: logFile.toString(true) }],
+        files: [{ name: viewPathUriString(logFile) }],
       };
 
       assert.strictEqual(result.log_dir, "");
       assert.strictEqual(result.files.length, 1);
       const [firstFile] = result.files;
       assert.ok(firstFile, "Expected at least one file");
-      assert.strictEqual(firstFile.name, logFile.toString(true));
+      assert.strictEqual(firstFile.name, viewPathUriString(logFile));
     });
 
-    test("should use toString(true) for log file path", () => {
+    test("should use canonical view path serialization", () => {
       const logFile = Uri.file("/test/log.json");
-      const name = logFile.toString(true);
+      const name = viewPathUriString(logFile);
 
       assert.ok(name.includes("file:"));
     });
@@ -406,6 +410,26 @@ suite("InspectViewServer Test Suite", () => {
 
       assert.strictEqual(headers.get(kViewScopeKindHeader), "directory");
       assert.strictEqual(headers.get(kViewScopeHeader), "s3://bucket/logs");
+    });
+
+    test("scope headers preserve canonical signed query parameters", async () => {
+      const headers = new Headers();
+      await addViewScopeHeaders(
+        headers,
+        fileViewPathScope(
+          Uri.parse(
+            "https://example.test/run.eval?" +
+              "credential=team%2Fmember&label=hello%20world"
+          )
+        )
+      );
+
+      assert.strictEqual(headers.get(kViewScopeKindHeader), "file");
+      assert.strictEqual(
+        headers.get(kViewScopeHeader),
+        "https://example.test/run.eval?" +
+          "credential=team%2Fmember&label=hello%20world"
+      );
     });
   });
 

--- a/src/test/suite/log-listing.test.ts
+++ b/src/test/suite/log-listing.test.ts
@@ -2,10 +2,17 @@
  * Tests for log-listing.ts and log-listing-data.ts - LogListing and TreeDataProviders
  */
 import * as assert from "assert";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "fs/promises";
+import * as os from "os";
+import path from "path";
 
 import { Uri } from "vscode";
 
-import { directoryViewPathScope } from "../../core/uri";
+import {
+  directoryViewPathScope,
+  fileViewPathScope,
+  pathIsInViewScope,
+} from "../../core/uri";
 import {
   filterLogItemsToViewScope,
   relativeLogPath,
@@ -16,6 +23,7 @@ import {
  */
 interface LogItem {
   name: string;
+  scope_location?: string;
   mtime: number;
   display_name: string;
   item_id: string;
@@ -62,6 +70,60 @@ suite("Log Listing Scope", () => {
       filtered.map((item) => item.name),
       ["s3://bucket/logs/allowed.eval"]
     );
+    assert.strictEqual(
+      filtered[0]?.scope_location,
+      "s3://bucket/logs/allowed.eval"
+    );
+  });
+
+  test("freezes a local listing item before a symlink is retargeted", async function () {
+    if (os.platform() === "win32") {
+      this.skip();
+      return;
+    }
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "inspect-listing-"));
+    try {
+      const root = path.join(tempDir, "logs");
+      const first = path.join(root, "first");
+      const outside = path.join(tempDir, "outside");
+      const selected = path.join(root, "selected");
+      await mkdir(first, { recursive: true });
+      await mkdir(outside);
+      await writeFile(path.join(first, "run.eval"), "first");
+      await writeFile(path.join(outside, "run.eval"), "outside");
+      await symlink(first, selected, "dir");
+
+      const [item] = await filterLogItemsToViewScope(
+        directoryViewPathScope(Uri.file(root)),
+        [
+          {
+            name: Uri.file(path.join(selected, "run.eval")).toString(),
+            mtime: 1,
+            display_name: "run",
+            item_id: "run",
+          },
+        ]
+      );
+      assert.ok(item?.scope_location);
+
+      await rm(selected);
+      await symlink(outside, selected, "dir");
+
+      const frozenScope = fileViewPathScope(
+        Uri.parse(item.scope_location),
+        undefined,
+        item.scope_location
+      );
+      assert.strictEqual(
+        await pathIsInViewScope(
+          frozenScope,
+          Uri.file(path.join(selected, "run.eval"))
+        ),
+        false
+      );
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/test/suite/log-listing.test.ts
+++ b/src/test/suite/log-listing.test.ts
@@ -3,7 +3,13 @@
  */
 import * as assert from "assert";
 
-import { relativeLogPath } from "../../providers/activity-bar/log-listing/log-listing";
+import { Uri } from "vscode";
+
+import { directoryViewPathScope } from "../../core/uri";
+import {
+  filterLogItemsToViewScope,
+  relativeLogPath,
+} from "../../providers/activity-bar/log-listing/log-listing";
 
 /**
  * Mock LogItem for testing
@@ -29,6 +35,35 @@ interface LogDirectory {
 type LogNode =
   | ({ type: "dir"; parent?: LogNode } & LogDirectory)
   | ({ type: "file"; parent?: LogNode } & LogItem);
+
+suite("Log Listing Scope", () => {
+  test("drops traversal entries before they can become file grants", async () => {
+    const items: LogItem[] = [
+      {
+        name: "s3://bucket/logs/allowed.eval",
+        mtime: 1,
+        display_name: "allowed",
+        item_id: "allowed",
+      },
+      {
+        name: "s3://bucket/logs/../secret.eval",
+        mtime: 1,
+        display_name: "secret",
+        item_id: "secret",
+      },
+    ];
+
+    const filtered = await filterLogItemsToViewScope(
+      directoryViewPathScope(Uri.parse("s3://bucket/logs")),
+      items
+    );
+
+    assert.deepStrictEqual(
+      filtered.map((item) => item.name),
+      ["s3://bucket/logs/allowed.eval"]
+    );
+  });
+});
 
 /**
  * Build a log tree from flat list of items

--- a/src/test/suite/logview-editor.test.ts
+++ b/src/test/suite/logview-editor.test.ts
@@ -1,0 +1,43 @@
+import * as assert from "assert";
+
+import { Uri } from "vscode";
+
+import { resolveLogDocumentLocation } from "../../providers/logview/logview-editor";
+
+suite("Logview Editor Test Suite", () => {
+  test("separates sample navigation state from a local resource URI", () => {
+    const location = resolveLogDocumentLocation(
+      Uri.file("/logs/run.eval").with({
+        query: "sample_id=sample-1&epoch=2",
+        fragment: "ignored",
+      })
+    );
+
+    assert.strictEqual(location.resourceUri.query, "");
+    assert.strictEqual(location.resourceUri.fragment, "");
+    assert.strictEqual(location.sample_id, "sample-1");
+    assert.strictEqual(location.epoch, "2");
+  });
+
+  test("preserves a signed URL query as resource identity", () => {
+    const uri = Uri.parse(
+      "https://example.test/run.eval?expires=60&signature=selected"
+    );
+    const location = resolveLogDocumentLocation(uri);
+
+    assert.strictEqual(location.resourceUri.query, uri.query);
+    assert.strictEqual(location.sample_id, undefined);
+    assert.strictEqual(location.epoch, undefined);
+  });
+
+  test("does not rewrite mixed resource and navigation parameters", () => {
+    const uri = Uri.parse(
+      "https://example.test/run.eval?signature=selected&sample_id=sample-1&epoch=2"
+    );
+    const location = resolveLogDocumentLocation(uri);
+
+    assert.strictEqual(location.resourceUri.query, uri.query);
+    assert.strictEqual(location.sample_id, undefined);
+    assert.strictEqual(location.epoch, undefined);
+  });
+});

--- a/src/test/suite/logview-editor.test.ts
+++ b/src/test/suite/logview-editor.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 
 import { Uri } from "vscode";
 
+import { viewPathUriString, withViewPathLocation } from "../../core/uri";
 import { resolveLogDocumentLocation } from "../../providers/logview/logview-editor";
 
 suite("Logview Editor Test Suite", () => {
@@ -15,6 +16,7 @@ suite("Logview Editor Test Suite", () => {
 
     assert.strictEqual(location.resourceUri.query, "");
     assert.strictEqual(location.resourceUri.fragment, "");
+    assert.strictEqual(location.canonicalLocation, false);
     assert.strictEqual(location.sample_id, "sample-1");
     assert.strictEqual(location.epoch, "2");
   });
@@ -26,6 +28,19 @@ suite("Logview Editor Test Suite", () => {
     const location = resolveLogDocumentLocation(uri);
 
     assert.strictEqual(location.resourceUri.query, uri.query);
+    assert.strictEqual(location.resourceLocation, viewPathUriString(uri));
+    assert.strictEqual(location.sample_id, undefined);
+    assert.strictEqual(location.epoch, undefined);
+  });
+
+  test("uses the opaque URL carried by the editor URI", () => {
+    const raw = "https://example.test/run.eval?sample_id=a%26b&epoch=2";
+    const location = resolveLogDocumentLocation(
+      withViewPathLocation(Uri.parse(raw), raw)
+    );
+
+    assert.strictEqual(location.resourceLocation, raw);
+    assert.strictEqual(location.resourceUri.query, Uri.parse(raw).query);
     assert.strictEqual(location.sample_id, undefined);
     assert.strictEqual(location.epoch, undefined);
   });

--- a/src/test/suite/logview-state.test.ts
+++ b/src/test/suite/logview-state.test.ts
@@ -1,0 +1,74 @@
+import * as assert from "assert";
+
+import { Uri } from "vscode";
+
+import { viewPathScopesEqual } from "../../core/uri";
+import {
+  logFileIsInLogviewScope,
+  logviewPathScope,
+  LogviewState,
+} from "../../providers/logview/logview-state";
+
+suite("Logview State Test Suite", () => {
+  const logDir = Uri.file("/logs");
+  const firstLog = Uri.file("/logs/first.eval");
+  const secondLog = Uri.file("/logs/second.eval");
+
+  test("changes scope between directory and exact-file views", () => {
+    const directoryState: LogviewState = {
+      log_dir: logDir,
+      scope_kind: "directory",
+    };
+    const firstFileState: LogviewState = {
+      log_dir: logDir,
+      log_file: firstLog,
+      scope_kind: "file",
+    };
+    const secondFileState: LogviewState = {
+      log_dir: logDir,
+      log_file: secondLog,
+      scope_kind: "file",
+    };
+
+    assert.strictEqual(
+      viewPathScopesEqual(
+        logviewPathScope(directoryState),
+        logviewPathScope(firstFileState)
+      ),
+      false
+    );
+    assert.strictEqual(
+      viewPathScopesEqual(
+        logviewPathScope(firstFileState),
+        logviewPathScope(secondFileState)
+      ),
+      false
+    );
+  });
+
+  test("directory views accept child log updates", async () => {
+    const state: LogviewState = {
+      log_dir: logDir,
+      scope_kind: "directory",
+    };
+    const scope = logviewPathScope(state);
+
+    assert.strictEqual(await logFileIsInLogviewScope(scope, firstLog), true);
+    assert.strictEqual(
+      await logFileIsInLogviewScope(scope, Uri.file("/other/first.eval")),
+      false
+    );
+  });
+
+  test("file views accept updates only for the selected file", async () => {
+    const state: LogviewState = {
+      log_dir: logDir,
+      log_file: firstLog,
+      scope_kind: "file",
+    };
+    const scope = logviewPathScope(state);
+
+    assert.strictEqual(await logFileIsInLogviewScope(scope, firstLog), true);
+    assert.strictEqual(await logFileIsInLogviewScope(scope, secondLog), false);
+  });
+});

--- a/src/test/suite/uri.test.ts
+++ b/src/test/suite/uri.test.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { Uri } from "vscode";
 
 import {
+  canonicalViewPathLocationFromUri,
   directoryViewPathScope,
   dirname,
   fileViewPathScope,
@@ -15,7 +16,11 @@ import {
   prettyUriPath,
   resolvePathInViewScope,
   resolveToUri,
+  viewPathLocationFromUri,
+  viewPathScopeLocation,
   viewPathUriString,
+  withCanonicalViewPathLocation,
+  withViewPathLocation,
 } from "../../core/uri";
 
 suite("URI Utilities Test Suite", () => {
@@ -383,6 +388,48 @@ suite("URI Utilities Test Suite", () => {
         viewPathUriString(uri),
         "https://example.test/run.eval?" +
           "credential=team%2Fmember&label=hello%20world"
+      );
+    });
+
+    test("preserves opaque signed URLs exactly", async () => {
+      const location =
+        "https://example.test/run.eval?" +
+        "token=a%26b&credential=team%2Fmember";
+      const scope = fileViewPathScope(Uri.parse(location), location);
+
+      assert.strictEqual(await viewPathScopeLocation(scope), location);
+      assert.strictEqual(await pathIsInViewScope(scope, location), true);
+      assert.strictEqual(
+        await pathIsInViewScope(scope, Uri.parse(location)),
+        true
+      );
+      assert.strictEqual(
+        await pathIsInViewScope(
+          scope,
+          "https://example.test/run.eval?" +
+            "token=a&b&credential=team%2Fmember"
+        ),
+        false
+      );
+    });
+
+    test("round-trips opaque and canonical editor locations", () => {
+      const resource = Uri.parse("https://example.test/run.eval?token=a%26b");
+      const opaque = "https://example.test/run.eval?token=a%26b";
+      const canonical = "file:///tmp/logs/run.eval";
+
+      assert.strictEqual(
+        viewPathLocationFromUri(withViewPathLocation(resource, opaque)),
+        opaque
+      );
+      assert.strictEqual(
+        canonicalViewPathLocationFromUri(
+          withCanonicalViewPathLocation(
+            Uri.file("/tmp/logs/run.eval"),
+            canonical
+          )
+        ),
+        canonical
       );
     });
 

--- a/src/test/suite/uri.test.ts
+++ b/src/test/suite/uri.test.ts
@@ -347,6 +347,11 @@ suite("URI Utilities Test Suite", () => {
         await pathIsInViewScope(scope, "s3://bucket/logs/%2e%2e/secret"),
         false
       );
+      assert.throws(
+        () =>
+          directoryViewPathScope(Uri.parse("s3://user:password@bucket/logs")),
+        /Invalid viewer directory scope/
+      );
     });
 
     test("allows signed HTTP URLs only as an exact file scope", async () => {

--- a/src/test/suite/uri.test.ts
+++ b/src/test/suite/uri.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { mkdir, mkdtemp, rm, symlink, writeFile } from "fs/promises";
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "fs/promises";
 import * as os from "os";
 import path from "path";
 
@@ -74,6 +74,17 @@ suite("URI Utilities Test Suite", () => {
       const uri = resolveToUri("https://example.com/path#section");
       assert.strictEqual(uri.scheme, "https");
       assert.strictEqual(uri.fragment, "section");
+    });
+
+    test("should preserve a Windows UNC authority", function () {
+      if (os.platform() !== "win32") {
+        this.skip();
+        return;
+      }
+      const uri = resolveToUri("\\\\server\\share\\logs\\run.eval");
+      assert.strictEqual(uri.scheme, "file");
+      assert.strictEqual(uri.authority.toLowerCase(), "server");
+      assert.ok(uri.fsPath.toLowerCase().startsWith("\\\\server\\share\\"));
     });
   });
 
@@ -242,6 +253,17 @@ suite("URI Utilities Test Suite", () => {
       assert.strictEqual(await pathIsInViewScope(scope, sibling), false);
     });
 
+    test("allows a selected local directory before it exists", async () => {
+      const root = path.join(tempDir, "new-logs");
+      const scope = directoryViewPathScope(Uri.file(root));
+
+      assert.strictEqual(await pathIsInViewScope(scope, Uri.file(root)), true);
+      assert.strictEqual(
+        await pathIsInViewScope(scope, path.join(root, "run.eval")),
+        true
+      );
+    });
+
     test("resolves a selected symlink root and rejects nested escapes", async function () {
       if (os.platform() === "win32") {
         this.skip();
@@ -262,6 +284,38 @@ suite("URI Utilities Test Suite", () => {
       const scope = directoryViewPathScope(Uri.file(selected));
       assert.strictEqual(await pathIsInViewScope(scope, allowed), true);
       assert.strictEqual(await pathIsInViewScope(scope, rejected), false);
+    });
+
+    test("retains the selected symlink target as an immutable scope", async function () {
+      if (os.platform() === "win32") {
+        this.skip();
+        return;
+      }
+      const firstTarget = path.join(tempDir, "first");
+      const secondTarget = path.join(tempDir, "second");
+      const selected = path.join(tempDir, "selected");
+      await mkdir(firstTarget);
+      await mkdir(secondTarget);
+      await writeFile(path.join(firstTarget, "allowed.eval"), "allowed");
+      await writeFile(path.join(secondTarget, "secret.eval"), "secret");
+      await symlink(firstTarget, selected, "dir");
+
+      const scope = directoryViewPathScope(Uri.file(selected));
+      assert.strictEqual(
+        (await scope.canonicalUri).fsPath,
+        await realpath(firstTarget)
+      );
+      await rm(selected);
+      await symlink(secondTarget, selected, "dir");
+
+      assert.strictEqual(
+        await pathIsInViewScope(scope, path.join(selected, "allowed.eval")),
+        false
+      );
+      assert.strictEqual(
+        await pathIsInViewScope(scope, path.join(selected, "secret.eval")),
+        false
+      );
     });
 
     test("uses exact file scopes", async () => {
@@ -295,8 +349,9 @@ suite("URI Utilities Test Suite", () => {
       );
     });
 
-    test("allows HTTP only as an exact file scope", async () => {
-      const selected = "https://example.test/run.eval";
+    test("allows signed HTTP URLs only as an exact file scope", async () => {
+      const selected =
+        "https://example.test/run.eval?expires=60&signature=selected";
       assert.strictEqual(
         await pathIsInViewScope(
           fileViewPathScope(Uri.parse(selected)),
@@ -307,16 +362,27 @@ suite("URI Utilities Test Suite", () => {
       assert.strictEqual(
         await pathIsInViewScope(
           fileViewPathScope(Uri.parse(selected)),
-          "https://example.test/other.eval"
+          "https://example.test/run.eval?expires=60&signature=other"
         ),
         false
       );
       assert.strictEqual(
         await pathIsInViewScope(
-          directoryViewPathScope(Uri.parse("https://example.test/logs")),
-          selected
+          fileViewPathScope(Uri.parse(selected)),
+          "https://example.test/run.eval"
         ),
         false
+      );
+      assert.strictEqual(
+        await pathIsInViewScope(
+          fileViewPathScope(Uri.parse(selected)),
+          "https://example.test/other.eval?expires=60&signature=selected"
+        ),
+        false
+      );
+      assert.throws(
+        () => directoryViewPathScope(Uri.parse("https://example.test/logs")),
+        /Invalid viewer directory scope/
       );
     });
   });

--- a/src/test/suite/uri.test.ts
+++ b/src/test/suite/uri.test.ts
@@ -13,7 +13,9 @@ import {
   normalizeWindowsUri,
   pathIsInViewScope,
   prettyUriPath,
+  resolvePathInViewScope,
   resolveToUri,
+  viewPathUriString,
 } from "../../core/uri";
 
 suite("URI Utilities Test Suite", () => {
@@ -347,10 +349,40 @@ suite("URI Utilities Test Suite", () => {
         await pathIsInViewScope(scope, "s3://bucket/logs/%2e%2e/secret"),
         false
       );
+      assert.strictEqual(
+        await pathIsInViewScope(scope, "s3://bucket/logs/../secret"),
+        false
+      );
       assert.throws(
         () =>
           directoryViewPathScope(Uri.parse("s3://user:password@bucket/logs")),
         /Invalid viewer directory scope/
+      );
+    });
+
+    test("resolves remote aliases to the authorized resource", async () => {
+      const scope = fileViewPathScope(Uri.parse("memory://bucket/logs/secret"));
+      const resolved = await resolvePathInViewScope(
+        scope,
+        "memory://bucket/logs//secret"
+      );
+
+      assert.strictEqual(
+        resolved?.toString(true),
+        "memory://bucket/logs/secret"
+      );
+    });
+
+    test("serializes signed query values using canonical RFC3986 encoding", () => {
+      const uri = Uri.parse(
+        "https://example.test/run.eval?" +
+          "credential=team%2Fmember&label=hello%20world"
+      );
+
+      assert.strictEqual(
+        viewPathUriString(uri),
+        "https://example.test/run.eval?" +
+          "credential=team%2Fmember&label=hello%20world"
       );
     });
 

--- a/src/test/suite/uri.test.ts
+++ b/src/test/suite/uri.test.ts
@@ -1,12 +1,17 @@
 import * as assert from "assert";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "fs/promises";
 import * as os from "os";
+import path from "path";
 
 import { Uri } from "vscode";
 
 import {
+  directoryViewPathScope,
   dirname,
+  fileViewPathScope,
   getRelativeUri,
   normalizeWindowsUri,
+  pathIsInViewScope,
   prettyUriPath,
   resolveToUri,
 } from "../../core/uri";
@@ -196,6 +201,123 @@ suite("URI Utilities Test Suite", () => {
       const child = Uri.file("/home/user/project2/file.txt");
       const relative = getRelativeUri(parent, child);
       assert.strictEqual(relative, null);
+    });
+
+    test("should return null for prefix sibling paths", () => {
+      const parent = Uri.file("/home/user/logs");
+      const child = Uri.file("/home/user/logs-archive/file.txt");
+      assert.strictEqual(getRelativeUri(parent, child), null);
+    });
+
+    test("should require the same remote authority", () => {
+      const parent = Uri.parse("s3://bucket/logs");
+      const child = Uri.parse("s3://other/logs/file.txt");
+      assert.strictEqual(getRelativeUri(parent, child), null);
+    });
+  });
+
+  suite("view path scopes", () => {
+    let tempDir: string;
+
+    setup(async () => {
+      tempDir = await mkdtemp(path.join(os.tmpdir(), "inspect-view-scope-"));
+    });
+
+    teardown(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    test("allows canonical local descendants and rejects siblings", async () => {
+      const root = path.join(tempDir, "logs");
+      const nested = path.join(root, "nested");
+      const selected = path.join(nested, "run.eval");
+      const sibling = path.join(tempDir, "logs-archive", "run.eval");
+      await mkdir(nested, { recursive: true });
+      await mkdir(path.dirname(sibling), { recursive: true });
+      await writeFile(selected, "selected");
+      await writeFile(sibling, "sibling");
+
+      const scope = directoryViewPathScope(Uri.file(root));
+      assert.strictEqual(await pathIsInViewScope(scope, selected), true);
+      assert.strictEqual(await pathIsInViewScope(scope, sibling), false);
+    });
+
+    test("resolves a selected symlink root and rejects nested escapes", async function () {
+      if (os.platform() === "win32") {
+        this.skip();
+        return;
+      }
+      const target = path.join(tempDir, "target");
+      const selected = path.join(tempDir, "selected");
+      const outside = path.join(tempDir, "outside");
+      await mkdir(target);
+      await mkdir(outside);
+      await symlink(target, selected, "dir");
+      await symlink(outside, path.join(target, "escape"), "dir");
+      const allowed = path.join(selected, "run.eval");
+      const rejected = path.join(selected, "escape", "secret.eval");
+      await writeFile(path.join(target, "run.eval"), "selected");
+      await writeFile(path.join(outside, "secret.eval"), "secret");
+
+      const scope = directoryViewPathScope(Uri.file(selected));
+      assert.strictEqual(await pathIsInViewScope(scope, allowed), true);
+      assert.strictEqual(await pathIsInViewScope(scope, rejected), false);
+    });
+
+    test("uses exact file scopes", async () => {
+      const selected = path.join(tempDir, "selected.eval");
+      const sibling = path.join(tempDir, "sibling.eval");
+      await writeFile(selected, "selected");
+      await writeFile(sibling, "sibling");
+
+      const scope = fileViewPathScope(Uri.file(selected));
+      assert.strictEqual(await pathIsInViewScope(scope, selected), true);
+      assert.strictEqual(await pathIsInViewScope(scope, sibling), false);
+    });
+
+    test("contains remote descendants by components and authority", async () => {
+      const scope = directoryViewPathScope(Uri.parse("s3://bucket/logs"));
+      assert.strictEqual(
+        await pathIsInViewScope(scope, "s3://bucket/logs/run.eval"),
+        true
+      );
+      assert.strictEqual(
+        await pathIsInViewScope(scope, "s3://bucket/logs-archive/run.eval"),
+        false
+      );
+      assert.strictEqual(
+        await pathIsInViewScope(scope, "s3://other/logs/run.eval"),
+        false
+      );
+      assert.strictEqual(
+        await pathIsInViewScope(scope, "s3://bucket/logs/%2e%2e/secret"),
+        false
+      );
+    });
+
+    test("allows HTTP only as an exact file scope", async () => {
+      const selected = "https://example.test/run.eval";
+      assert.strictEqual(
+        await pathIsInViewScope(
+          fileViewPathScope(Uri.parse(selected)),
+          selected
+        ),
+        true
+      );
+      assert.strictEqual(
+        await pathIsInViewScope(
+          fileViewPathScope(Uri.parse(selected)),
+          "https://example.test/other.eval"
+        ),
+        false
+      );
+      assert.strictEqual(
+        await pathIsInViewScope(
+          directoryViewPathScope(Uri.parse("https://example.test/logs")),
+          selected
+        ),
+        false
+      );
     });
   });
 


### PR DESCRIPTION
## Related viewer security PRs

- [UKGovernmentBEIS/inspect_ai#4368](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4368) - Inspect standalone Host, Origin, authorization, and framing trust.
- [meridianlabs-ai/inspect_scout#482](https://github.com/meridianlabs-ai/inspect_scout/pull/482) - Scout standalone Host, Origin, authorization, and framing trust.

## Current behavior

The extension host starts one authorization-protected Inspect server and keeps the token out of the webview. Several JSON-RPC methods nevertheless forward a file path supplied by the webview without checking it against the directory or file used to create that panel.

`displayLogFile` can also supply a replacement `log_dir`, and background update checks do not use the same canonical scope as forwarded requests.

## New behavior

- Directory panels, individual-file views, custom editors, and activity-bar listings retain an immutable host-selected capability.
- Activity-bar file grants carry the resolved listing capability into the editor rather than re-resolving the original path.
- Local grants resolve the selected root once. Retargeting a selected symlink does not move an existing panel or listing to the new target.
- Missing local roots resolve through their nearest existing canonical parent.
- Every file, byte-range, batch-header, pending-sample, edit, message, transcript-search, navigation, background-refresh, and notification decision uses the same scope check.
- Batch requests fail before forwarding if any file is outside scope.
- Remote scopes compare scheme, authority, normalized path components, and exact file queries.
- Signed HTTP(S) URLs are retained as opaque exact file strings and survive editor restoration without query re-serialization.
- Custom-editor sample navigation parameters remain separate from signed resource queries.
- Windows UNC file authorities remain eligible local scopes on Windows and are rejected as remote file authorities elsewhere.
- Webview `displayLogFile` messages may navigate within the existing scope but cannot replace or enlarge it.
- Compatible Inspect versions receive the frozen canonical scope on each backend request.
- The generic `http_request` transport is registered and advertised only when Inspect supports scoped authorization, and it always receives the panel scope.
- Older Inspect versions fall back to the individually validated named RPC methods; direct generic calls are rejected before HTTP.

The startup argument is recalculated whenever the Inspect process restarts, so upgrading Inspect during an extension session enables the protocol correctly. Older Inspect versions remain protected by the extension's host-side checks.

## Compatibility

Normal directory browsing, individual-file editors, S3 and other configured remote roots, activity-bar operations, background refresh, exact signed HTTP(S) file opens, new/empty log directories, and Windows UNC locations remain supported.

The Inspect version threshold is currently `0.3.242` and should be adjusted to the actual companion release before merge if necessary.

The TypeScript and Python capability implementations intentionally remain local to their repositories while using matching conformance cases. Consolidation will be evaluated after rollout in [inspect_scout#484](https://github.com/meridianlabs-ai/inspect_scout/issues/484).

## Testing

- TypeScript typecheck, ESLint, and Prettier passed.
- Production webpack build passed.
- 503 VS Code extension tests passed under Xvfb, with 9 platform/asset tests skipped.
- Added immutable-root, missing-root, nested-symlink, file/directory transition, signed-query, background-update, Windows UNC URI, generic-proxy gating, and scope-forwarding coverage.
- The existing `windows-latest` PR job will exercise the Windows-specific extension tests once the fork workflow is approved.