### PR TITLE
fix: grant pull-requests: read to pr-title-lint caller

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -6,4 +6,6 @@ on:
 
 jobs:
   lint:
+    permissions:
+      pull-requests: read
     uses: meridianlabs-ai/actions/.github/workflows/pr-title-lint.yml@v1


### PR DESCRIPTION
Fixes the "Invalid workflow file … requesting 'pull-requests: read', but is only allowed 'pull-requests: none'" error.

The reusable `pr-title-lint.yml` declares it needs `pull-requests: read`; the repo's default `GITHUB_TOKEN` grants `none`, and a reusable workflow can't escalate beyond what the caller grants. This adds the `permissions` block to the caller job.

(The `release.yml` caller already had its permissions block, so only lint was affected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)