### PR TITLE
fix: skip Claude review on release-bot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,8 +12,12 @@ on:
 
 jobs:
   claude-review:
-    # Skip PRs opened by Claude bot
-    if: github.event.pull_request.user.login != 'claude[bot]' && github.actor != 'dependabot[bot]'
+    # Skip PRs opened by bots (Claude, Dependabot, and the release bot — release
+    # PRs are machine-generated changelog/version bumps that don't need AI review).
+    if: >-
+      github.event.pull_request.user.login != 'claude[bot]'
+      && github.event.pull_request.user.login != 'meridian-release-bot[bot]'
+      && github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Resolves `Workflow initiated by non-human actor: meridian-release-bot (type: Bot). Add bot to allowed_bots list…`.

`claude-code-review.yml` runs on `pull_request`; when `meridian-release-bot` opens the release PR, `anthropics/claude-code-action` refuses to run for a Bot actor. Rather than `allowed_bots` (which would make Claude *review* every auto-generated release PR), extend the existing bot-skip `if:` to also skip `meridian-release-bot[bot]` — matching how `claude[bot]` and `dependabot[bot]` are already skipped. Release PRs are generated changelog/version bumps and get a human review at merge anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)