### PR TITLE
fix: Fix possible file races in environment file management

### DIFF
--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -1,19 +1,12 @@
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 
 import { Uri } from "vscode";
 
 import { lines } from "./text";
 
 export const readEnv = (file: Uri): Record<string, string> => {
-  // There is no env file, no env settings
-  if (!existsSync(file.fsPath)) {
-    return {};
-  }
-
-  // Read the env file
+  // Read the env file (empty if there is no env file)
   const envLines = readEnvLines(file);
-
-  // Read the env file
   return envLines
     .map((line) => {
       return readLine(line);
@@ -31,7 +24,7 @@ export const readEnv = (file: Uri): Record<string, string> => {
 
 export const writeEnv = (key: string, value: string, file: Uri) => {
   // Read the env file
-  const envLines = existsSync(file.fsPath) ? readEnvLines(file) : [];
+  const envLines = readEnvLines(file);
   const outLines = [];
 
   let valueWritten = false;
@@ -53,7 +46,7 @@ export const writeEnv = (key: string, value: string, file: Uri) => {
 
 export const clearEnv = (key: string, file: Uri) => {
   // Read the env file
-  const envLines = existsSync(file.fsPath) ? readEnvLines(file) : [];
+  const envLines = readEnvLines(file);
   const outLines = [];
 
   for (const line of envLines) {
@@ -91,7 +84,17 @@ function readLine(line: string) {
 }
 
 function readEnvLines(file: Uri) {
-  const envRaw = readFileSync(file.fsPath, { encoding: "utf-8" });
+  // Treat a missing env file as empty rather than checking existence
+  // beforehand (the file could appear or disappear in between)
+  let envRaw: string;
+  try {
+    envRaw = readFileSync(file.fsPath, { encoding: "utf-8" });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
   return lines(envRaw);
 }
 

--- a/src/core/jsonrpc.ts
+++ b/src/core/jsonrpc.ts
@@ -46,6 +46,11 @@ export function webViewJsonRpcClient(vscode: {
     },
     onMessage: (handler: (data: unknown) => void) => {
       const onMessage = (ev: MessageEvent) => {
+        // Only handle messages relayed by the VS Code webview host (the
+        // webview's parent frame) — ignore anything posted by other windows.
+        if (ev.origin !== window.origin && ev.source !== window.parent) {
+          return;
+        }
         handler(ev.data);
       };
       window.addEventListener("message", onMessage);

--- a/src/core/package/output-watcher.ts
+++ b/src/core/package/output-watcher.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync } from "fs";
+import { closeSync, fstatSync, openSync, readFileSync } from "fs";
 
 import { Disposable, Event, EventEmitter, Uri } from "vscode";
 
@@ -42,8 +42,19 @@ export class OutputWatcher implements Disposable {
 
     this.watchInterval_ = setInterval(() => {
       for (const evalSignalFile of evalSignalFiles) {
-        if (existsSync(evalSignalFile.path)) {
-          const updated = statSync(evalSignalFile.path).mtime.getTime();
+        // Open the signal file and stat/read through the file descriptor so
+        // that the mtime check and the read can't race a concurrent
+        // delete/replace of the file
+        let fd: number;
+        try {
+          fd = openSync(evalSignalFile.path, "r");
+        } catch {
+          // There is no signal file (yet)
+          continue;
+        }
+
+        try {
+          const updated = fstatSync(fd).mtime.getTime();
 
           const lastTime =
             evalSignalFile.type === "log" ? this.lastLog_ : this.lastScan_;
@@ -57,7 +68,7 @@ export class OutputWatcher implements Disposable {
 
             let evalLogPath: string | undefined;
             let workspaceId;
-            const contents = readFileSync(evalSignalFile.path, {
+            const contents = readFileSync(fd, {
               encoding: "utf-8",
             });
 
@@ -108,6 +119,8 @@ export class OutputWatcher implements Disposable {
               }
             }
           }
+        } finally {
+          closeSync(fd);
         }
       }
     }, 500);

--- a/src/providers/activity-bar/webview/env-utils.ts
+++ b/src/providers/activity-bar/webview/env-utils.ts
@@ -12,7 +12,7 @@ import {
 } from "@vscode/webview-ui-toolkit";
 
 import { attachModelListeners } from "./env-utils-model";
-import { showEmptyPanel } from "./webview-utils";
+import { isMessageFromHost, showEmptyPanel } from "./webview-utils";
 
 // Declare the acquireVsCodeApi function to tell TypeScript about it
 declare function acquireVsCodeApi(): any;
@@ -32,6 +32,9 @@ export function initEnv(
 
   // Process messages
   window.addEventListener("message", (e) => {
+    if (!isMessageFromHost(e)) {
+      return;
+    }
     switch (e.data.type) {
       case "initialize":
         // Set the env values

--- a/src/providers/activity-bar/webview/scout-panel-webview.ts
+++ b/src/providers/activity-bar/webview/scout-panel-webview.ts
@@ -6,6 +6,8 @@ import {
   provideVSCodeDesignSystem,
 } from "@vscode/webview-ui-toolkit";
 
+import { isMessageFromHost } from "./webview-utils";
+
 // Declare the acquireVsCodeApi function
 declare function acquireVsCodeApi(): {
   postMessage(message: unknown): void;
@@ -20,6 +22,9 @@ function init() {
 
   // Handle messages from the extension
   window.addEventListener("message", (e: MessageEvent) => {
+    if (!isMessageFromHost(e)) {
+      return;
+    }
     const message = e.data;
     switch (message.type) {
       case "initialize":

--- a/src/providers/activity-bar/webview/task-config-webview.ts
+++ b/src/providers/activity-bar/webview/task-config-webview.ts
@@ -14,6 +14,7 @@ import {
 import { DocumentState } from "../../workspace/workspace-state-provider";
 
 import {
+  isMessageFromHost,
   restoreInputState,
   setControlsVisible,
   showEmptyPanel,
@@ -34,6 +35,9 @@ const vscode = acquireVsCodeApi();
 
 // Process messages
 window.addEventListener("message", (e) => {
+  if (!isMessageFromHost(e)) {
+    return;
+  }
   switch (e.data.type) {
     case "initialize":
       showEmptyPanel("No task selected", "configuration-controls");

--- a/src/providers/activity-bar/webview/webview-utils.ts
+++ b/src/providers/activity-bar/webview/webview-utils.ts
@@ -2,6 +2,12 @@ import { debounce } from "lodash";
 
 export const kBounceInterval = 200;
 
+// True when a message event was relayed by the VS Code webview host (the
+// webview's parent frame) rather than posted by some other window.
+export const isMessageFromHost = (e: MessageEvent) => {
+  return e.origin === window.origin || e.source === window.parent;
+};
+
 export const restoreInputState = (id: string, value?: string) => {
   const el = document.getElementById(id) as HTMLInputElement;
   if (value) {

--- a/src/providers/workspace/workspace-env-commands.ts
+++ b/src/providers/workspace/workspace-env-commands.ts
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from "fs";
+import { writeFileSync } from "fs";
 
 import { window, workspace } from "vscode";
 
@@ -15,10 +15,9 @@ export class EditEnvFileCommand implements Command {
     // The path to the env file
     const absPath = workspacePath(`.env`);
 
-    // Ensure env file actually exists
-    if (!existsSync(absPath.path)) {
-      writeFileSync(absPath.path, "", { encoding: "utf-8" });
-    }
+    // Ensure env file actually exists (append mode creates the file if
+    // missing without truncating one created in the meantime)
+    writeFileSync(absPath.path, "", { encoding: "utf-8", flag: "a" });
 
     // Open the env file
     const document = await workspace.openTextDocument(absPath.path);


### PR DESCRIPTION
Fixes all 8 open CodeQL alerts from the [code scanning page](https://github.com/meridianlabs-ai/inspect_vscode/security/code-scanning) (`security-and-quality` suite).

## `js/missing-origin-check` — alerts #9–#12 (medium)

Webview-side `window.addEventListener("message", ...)` handlers accepted messages from any window. In VS Code webviews, legitimate extension messages are relayed by the webview host — the webview's parent frame — so the handlers now ignore anything else:

- Added a shared `isMessageFromHost()` helper in `webview-utils.ts`: accepts a message when `e.source === window.parent` (the host relay) or `e.origin === window.origin` (our own origin). The `source` check is the platform-independent one (the host frame origin differs between desktop/web/remote); the `origin` check is a complementary same-origin acceptance so legitimate delivery can't break.
- Applied it in `task-config-webview.ts`, `scout-panel-webview.ts`, and `env-utils.ts` (env-config webviews), and added an equivalent inline guard in `webViewJsonRpcClient` in `src/core/jsonrpc.ts` (core can't import from providers).

## `js/file-system-race` — alerts #5–#8 (high)

All four were check-then-use (TOCTOU) patterns, replaced with atomic or error-handling equivalents:

- **`src/core/env.ts`** (#5, #6): `readEnvLines()` now reads and treats `ENOENT` as an empty file instead of the callers guarding with `existsSync` before read/write. Behavior is unchanged for the missing-file case; other read errors still propagate as before.
- **`src/providers/workspace/workspace-env-commands.ts`** (#8): the "ensure `.env` exists" step now writes with `flag: "a"` (append creates the file if missing) instead of `existsSync` + truncating write, so a file created concurrently can no longer be clobbered.
- **`src/core/package/output-watcher.ts`** (#7): the 500ms poller did `existsSync` → `statSync` → `readFileSync` on the eval signal file; a delete/replace between those calls could throw an unhandled exception in the interval callback or read torn state. It now opens the file once and does `fstatSync`/`readFileSync` through the file descriptor (closed in `finally`), so the mtime check and read are against the same file, and a missing file is just skipped.

## Not addressed

Dependabot alert #87 (dependency vulnerability) is separate from code scanning and not touched here.

## Testing

- `pnpm check` — lint, format:check, and typecheck pass; all webpack builds (extension + 3 webview bundles) compile. The `pnpm test` step couldn't run in the sandbox (it downloads VS Code from `update.code.visualstudio.com`, which is blocked there) — relying on CI for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJ1M1T3RPySYnDF46dphUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJ1M1T3RPySYnDF46dphUY)_