### PR TITLE
chore: align release CODEOWNERS with marketplace env reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 # without affecting normal feature PRs. Pair with the `protect main` ruleset's
 # "Require review from Code Owners".
 
-/CHANGELOG.md                    @dragonstyle @jjallaire @epatey
-/.release-please-manifest.json   @dragonstyle @jjallaire @epatey
+/CHANGELOG.md                    @dragonstyle @epatey @brandly
+/.release-please-manifest.json   @dragonstyle @epatey @brandly


### PR DESCRIPTION
Aligns the two release gates to the same people. The `marketplace` environment's required reviewers are `@dragonstyle @epatey @brandly`; this updates CODEOWNERS (release-PR gate) to match — removing `@jjallaire` and adding `@brandly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)