### PR TITLE
docs: note PR titles and automated releases in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,13 +151,17 @@ refactor: Extract webview messaging into separate module
 
 ### How commits become releases
 
-Because we squash-merge, **the PR title becomes the commit message** that
-[Release Please](https://github.com/googleapis/release-please) reads — so format
-the PR title as a conventional commit too. Only `feat:` and `fix:` appear in the
-release notes and drive the version bump; reserve them for user-facing changes.
+Format the **PR title as a conventional commit** (`<type>: <description>`) — that's
+what `pr-title-lint` enforces and what
+[Release Please](https://github.com/googleapis/release-please) reads to build the
+changelog and pick the next version. Use `feat:`/`fix:` for user-facing changes:
+they headline the release notes and drive the version bump (`feat` → minor,
+`fix` → patch, a breaking change → major). `perf:`/`revert:` also appear in the
+notes; `docs:`/`refactor:`/`chore:`/`build:`/`ci:`/`test:` are hidden.
 
 **Don't edit `CHANGELOG.md` or bump the version by hand.** Release Please opens a
-release PR that updates both; merging that PR tags and publishes the extension.
+release PR that updates both; merging it tags the release, and — once a maintainer
+approves the `marketplace` deployment — publishes the extension.
 
 ## Building for Release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,16 @@ docs: Update installation instructions
 refactor: Extract webview messaging into separate module
 ```
 
+### How commits become releases
+
+Because we squash-merge, **the PR title becomes the commit message** that
+[Release Please](https://github.com/googleapis/release-please) reads — so format
+the PR title as a conventional commit too. Only `feat:` and `fix:` appear in the
+release notes and drive the version bump; reserve them for user-facing changes.
+
+**Don't edit `CHANGELOG.md` or bump the version by hand.** Release Please opens a
+release PR that updates both; merging that PR tags and publishes the extension.
+
 ## Building for Release
 
 ```bash


### PR DESCRIPTION
Adds a **How commits become releases** note to the existing Commit Messages section: PR titles are what Release Please reads (we squash-merge), `feat:`/`fix:` drive the notes + version bump, and the changelog/version/publish are automated (no hand edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)