### PR TITLE
ci: enable manual/hotfix dispatch (single-control)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      target-branch:
-        description: "Maintenance branch to release from (e.g. hotfix/1.4.x). Must match the branch selected in 'Use workflow from' (publish checks out that ref). Leave as main for a normal release."
-        type: string
-        default: main
 
 jobs:
   release:
@@ -18,5 +13,4 @@ jobs:
     uses: meridianlabs-ai/actions/.github/workflows/release-please-vscode.yml@v1
     with:
       extension-id: ukaisi.inspect-ai
-      target-branch: ${{ inputs.target-branch }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      target-branch:
+        description: "Maintenance branch to release from (e.g. hotfix/1.4.x). Leave as main for a normal release."
+        type: string
+        default: main
 
 jobs:
   release:
@@ -12,4 +18,5 @@ jobs:
     uses: meridianlabs-ai/actions/.github/workflows/release-please-vscode.yml@v1
     with:
       extension-id: ukaisi.inspect-ai
+      target-branch: ${{ inputs.target-branch }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       target-branch:
-        description: "Maintenance branch to release from (e.g. hotfix/1.4.x). Leave as main for a normal release."
+        description: "Maintenance branch to release from (e.g. hotfix/1.4.x). Must match the branch selected in 'Use workflow from' (publish checks out that ref). Leave as main for a normal release."
         type: string
         default: main
 


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger with a `target-branch` input and passes it through to the reusable `release-please-vscode.yml@v1` workflow. Backward compatible: on push, `inputs.target-branch` is empty and the reusable workflow falls back to the default branch (unchanged behavior). This enables maintenance-branch hotfix releases by dispatching against a branch like `hotfix/1.4.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)