### PR TITLE
chore: regenerate release-please config (drop invalid key, hide docs/chore/refactor)

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,6 +1,5 @@
 {
   "release-type": "node",
-  "include-v-in-tag": true,
   "packages": {
     ".": {
       "changelog-sections": [
@@ -22,15 +21,18 @@
         },
         {
           "type": "refactor",
-          "section": "Code Refactoring"
+          "section": "Code Refactoring",
+          "hidden": true
         },
         {
           "type": "docs",
-          "section": "Documentation"
+          "section": "Documentation",
+          "hidden": true
         },
         {
           "type": "chore",
-          "section": "Miscellaneous"
+          "section": "Miscellaneous",
+          "hidden": true
         },
         {
           "type": "build",
@@ -52,10 +54,7 @@
           "section": "Styles",
           "hidden": true
         }
-      ],
-      "release-notes-config": {
-        "grouping": true
-      }
+      ]
     }
   }
 }


### PR DESCRIPTION
Removes the invalid `release-notes-config` key and hides `docs`/`chore`/`refactor` so release notes surface `feat`/`fix`/`perf`/`revert` only. Mirrors meridianlabs-ai/actions#64/#65.

Also drops a redundant top-level `include-v-in-tag: true` — the default is already `true`, so tags stay `v`-prefixed (no behavior change; just normalizes to the generator's canonical output). `release-type` (node) and versioning unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)