### PR TITLE
chore: keep plain v-prefixed tags (no component prefix) in manifest mode

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -2,6 +2,7 @@
   "release-type": "node",
   "packages": {
     ".": {
+      "include-component-in-tag": false,
       "changelog-sections": [
         {
           "type": "feat",


### PR DESCRIPTION
## Problem

Release PR #138 proposes **`inspect-ai 0.3.65`** with a changelog full of already-released items. Root cause: when the reusable workflow dropped the `release-type` input (meridianlabs-ai/actions#65 — correct fix, moved everything to manifest mode), the **node strategy's default tag format changed** from plain `v0.9.14` to component-prefixed `inspect-ai-v0.9.14` (component = package.json `name`). RP found no `inspect-ai-v*` tags in history, concluded the package had never been released, and recomputed version + changelog from scratch.

## Fix

`include-component-in-tag: false` → manifest mode tags plain `v{version}`, matching the existing `v0.9.x` history, so RP re-anchors on `v0.9.14` and the next release computes as `v0.9.15` with a normal changelog.

(Python repos are unaffected — the python strategy doesn't prefix components, which is why scout's tags were fine.)

## After merging

The stale release PR #138 must be closed + regenerated (reopening dance) — RP won't recompute an existing release PR incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)