### PR TITLE
ci: skip auto-review for release-bot, fork, and Dependabot PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,8 +22,20 @@ jobs:
   review:
     # Run on PR events, or on a PR comment containing @review. `@review` does
     # not collide with the dev agent's `@claude` trigger.
+    #
+    # Auto-review is skipped for:
+    # - Release Please PRs (meridian-release-bot): machine-generated
+    #   changelog/version bumps — the review action also rejects non-human
+    #   actors, so these runs could only fail.
+    # - PRs from forks and Dependabot: GitHub withholds the OIDC id-token from
+    #   those pull_request runs, so the reviewer's WIF auth cannot work.
+    # All are still reviewable on demand via an @review comment (issue_comment
+    # runs in the base-repo context as the human commenter).
     if: >
-      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]' &&
+       github.event.pull_request.user.login != 'meridian-release-bot[bot]') ||
       (github.event.issue.pull_request != null &&
        contains(github.event.comment.body, '@review'))
     uses: meridianlabs-ai/agents/.github/workflows/claude-review.yml@main


### PR DESCRIPTION
## Problem

Every Release Please PR gets a failing `review / review` check (seen on #146):

> `Workflow initiated by non-human actor: meridian-release-bot (type: Bot)`

The shared reviewer's action rejects bot-initiated runs, so the auto-review on release PRs can only fail. (Not merge-blocking — the check isn't required — but a permanent red X on every release.) Fork and Dependabot PRs have the sibling problem: GitHub withholds the OIDC id-token from those `pull_request` runs, so WIF auth can't mint a token (same fix as meridianlabs-ai/ts-mono#419).

## Fix

Gate the `pull_request` auto-trigger to same-repo, human-authored PRs (excludes `meridian-release-bot[bot]` and `dependabot[bot]`). Release PRs are machine-generated changelog/version bumps with nothing to review; anything that does want review can still get it on demand via an `@review` comment, which runs in the base-repo context as the human commenter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)