### PR TITLE
ci: skip auto-review for dependabot PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,12 +22,14 @@ on:
 jobs:
   review:
     # Run on PR events (skipping drafts — they get reviewed via
-    # ready_for_review when marked ready), or on a PR comment containing
-    # @review. An explicit @review still works on a draft. `@review` does not
+    # ready_for_review when marked ready — and dependabot PRs, which don't
+    # need agent review), or on a PR comment containing @review. An explicit
+    # @review still works on a draft or dependabot PR. `@review` does not
     # collide with the dev agent's `@claude` trigger.
     if: >
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.draft != true) ||
+       github.event.pull_request.draft != true &&
+       github.event.pull_request.user.login != 'dependabot[bot]') ||
       (github.event.issue.pull_request != null &&
        contains(github.event.comment.body, '@review'))
     uses: meridianlabs-ai/agents/.github/workflows/claude-review.yml@main


### PR DESCRIPTION
The Review workflow currently auto-reviews every non-draft PR on open, including dependabot's. This adds a guard so PRs authored by `dependabot[bot]` are skipped on the `pull_request` trigger.

The explicit `@review` comment path is unchanged, so a review can still be requested on a dependabot PR when wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)